### PR TITLE
Ignore unicode errors in source code

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -68,7 +68,6 @@ class Coveralls(object):
         # Force unicode of source files
         clean_sourcefiles = []
         for source_file in data['source_files']:
-            print source_file['name']
             clean_sourcefiles.append(
                 {
                     'name': source_file['name'],


### PR DESCRIPTION
I was having a problem where a library from the python standard lib had an encoding error in coverage and this was stopping me from uploading coverage information about my code. This is a (rather hacky) solution to that problem.
