### PR TITLE
Pulling the use of ENV var COVERALLS_REPO_TOKEN out of Travis if block...

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -49,11 +49,12 @@ class Coveralls(object):
             is_travis = True
             self.config['service_name'] = file_config.get('service_name', None) or 'travis-ci'
             self.config['service_job_id'] = os.environ.get('TRAVIS_JOB_ID')
-            if os.environ.get('COVERALLS_REPO_TOKEN', None):
-                self.config['repo_token'] = os.environ.get('COVERALLS_REPO_TOKEN')
         else:
             is_travis = False
             self.config['service_name'] = file_config.get('service_name') or self.default_client
+
+        if os.environ.get('COVERALLS_REPO_TOKEN', None):
+            self.config['repo_token'] = os.environ.get('COVERALLS_REPO_TOKEN')
 
         if not self.config.get('repo_token') and not is_travis:
             raise CoverallsException('You have to provide either repo_token in %s, or launch via Travis' % self.config_filename)


### PR DESCRIPTION
...and use it no matter what CI service is used.  I've tested this on CircleCI and it works.  

But what are the usual commands so that test coverage is only reported for our code.

I'm new to python/django and their test suites.

I'm noticing that:
1) running "coverage run livenation_users/manage.py test && coveralls"  I get code coverage reported to coveralls.io for ALL code including the site-packages, which I don't want to see
2) coveralls.io sees the branch pushed as master when it was a totally different branch

Any help would be appreciated.  Thanks.
