### PR TITLE
Use CIRCLE_BRANCH env var for reported branch instead of HEAD for CircleCI

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -150,7 +150,7 @@ class Coveralls(object):
                 'committer_email': gitlog('%ce'),
                 'message': gitlog('%s'),
             },
-            'branch': os.environ.get('CIRCLE_BRANCH', None) if os.environ.get('CIRCLE_BRANCH') else os.environ.get('TRAVIS_BRANCH', git('rev-parse', '--abbrev-ref', 'HEAD').strip()), 
+            'branch': os.environ.get('CIRCLE_BRANCH') or os.environ.get('TRAVIS_BRANCH', git('rev-parse', '--abbrev-ref', 'HEAD').strip()), 
             #origin	git@github.com:coagulant/coveralls-python.git (fetch)
             'remotes': [{'name': line.split()[0], 'url': line.split()[1]}
                         for line in git.remote('-v') if '(fetch)' in line]


### PR DESCRIPTION
I've tested this and it works.  I tried to figure out how to do a more generic if/then/else in that hash but I'm new to python and couldn't figure out the best syntax.  So this oneliner seemed the next obvious choice.  It uses CIRCLE_BRANCH if its set, otherwise it uses what was there before.   If you have a cleaner way of doing it that could easily include other cloud CI services in the future, let me know.
