### PR TITLE
Fix issue with gitlog when output contained utf8

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -184,10 +184,19 @@ class Coveralls(object):
 
 
 def gitlog(format):
-    return str(run_command('git', '--no-pager', 'log', "-1", '--pretty=format:%s' % format))
+    try:
+        log = str(run_command('git', '--no-pager', 'log', "-1", '--pretty=format:%s' % format))
+    except UnicodeEncodeError:
+        log = unicode(run_command('git', '--no-pager', 'log', "-1", '--pretty=format:%s' % format))
+    return log
 
 
 def run_command(*args):
     cmd = subprocess.Popen(list(args), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     assert cmd.wait() == 0
-    return cmd.stdout.read().decode()
+    output = cmd.stdout.read()
+    try:
+        output = output.decode()
+    except UnicodeDecodeError:
+        output = output.decode('utf-8')
+    return output

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,7 +23,7 @@ class GitBasedTest(unittest.TestCase):
         self.dir = tempfile.mkdtemp()
         sh.cd(self.dir)
         sh.git.init()
-        sh.git('config', 'user.name', '"Guido"')
+        sh.git('config', 'user.name', '"Daniël"')
         sh.git('config', 'user.email', '"me@here.com"')
         sh.touch('README')
         sh.git.add('README')
@@ -91,9 +91,9 @@ class Git(GitBasedTest):
             'head': {
                 'committer_email': 'me@here.com',
                 'author_email': 'me@here.com',
-                'author_name': 'Guido',
+                'author_name': 'Daniël',
                 'message': 'first commit',
-                'committer_name': 'Guido',
+                'committer_name': 'Daniël',
             },
             'remotes': [{
                 'url': 'https://github.com/username/Hello-World.git',


### PR DESCRIPTION
When the git log command contained utf-8 characters, coveralls crashed with a
UnicodeDecodeError. This patch keeps the original behaviour unless the
UnicodeDecodeError is raised and will decode the text as utf-8 instead.

It might be cleaner to fix it by looking at the current locale or just assume
utf-8 but this seemed like the easiest and safest change for the time being.
