### PR TITLE
.coverage.rc -> .coveragerc and code format fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,7 @@ Nosetests
 
 However, it gathers coverage for all executed code, ignoring ``source`` config option in ``.coveragerc``.
 It means, that ``coveralls`` will report unnecessary files, which is inconvenient.
-Here is a workaround, use ``omit`` option in your ``.coverage.rc``to specify a list of filename patterns,
+Here is a workaround, use ``omit`` option in your ``.coveragerc`` to specify a list of filename patterns,
 the files to leave out of reporting (your paths might differ) ::
 
     [report]


### PR DESCRIPTION
I was running through this the README setting up my project for coveralls and got a little thrown off because the filename was wrong here. This fixes that. Also, a space was missing after the filename, throwing off the code formatting.
