### PR TITLE
Fix #41 arising from 503 errors from coveralls.io

### DIFF
--- a/coveralls/cli.py
+++ b/coveralls/cli.py
@@ -58,7 +58,7 @@ def main(argv=None):
         log.info('Aborted')
     except CoverallsException as e:
         log.error(e)
-    except KeyError:  # pragma: no cover
+    except KeyError as e:  # pragma: no cover
         log.error(e)
     except Exception:  # pragma: no cover
         raise


### PR DESCRIPTION
Solves issues with breaking builds due to flakiness on coverall's end.
