### PR TITLE
Fix the coverage version constraint.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
             'coveralls = coveralls.cli:main',
         ],
     },
-    install_requires=['PyYAML>=3.10', 'docopt>=0.6.1', 'coverage>=3.6,<4.0a', 'requests>=1.0.0'],
+    install_requires=['PyYAML>=3.10', 'docopt>=0.6.1', 'coverage>=3.6,<3.999', 'requests>=1.0.0'],
     tests_require=['mock', 'pytest', 'sh>=1.08'],
     cmdclass={'test': PyTest},
     classifiers=[


### PR DESCRIPTION
Ooops, embarrassing as it is, my previous PR is wrong. `coverage>=3.6,<4.0` will match `4.0a`, as `4.0a` is a lesser version than the `4.0` (a final release).
