### PR TITLE
fix(github): send null job_id to fix 422 during resubmission

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -235,9 +235,14 @@ class Coveralls:
             # attach a random value to ensure uniqueness
             # TODO: an auto-incrementing integer might be easier to reason
             # about if we could fetch the previous value
-            new_id = '{}-{}'.format(
-                self.config.get('service_job_id', 42),
-                random.randint(0, sys.maxsize))
+            # N.B. Github Actions fails if this is not set to null.
+            # Other services fail if this is set to null. Sigh x2.
+            if os.environ.get('GITHUB_REPOSITORY'):
+                new_id = None
+            else:
+                new_id = '{}-{}'.format(
+                    self.config.get('service_job_id', 42),
+                    random.randint(0, sys.maxsize))
             print('resubmitting with id {}'.format(new_id))
 
             self.config['service_job_id'] = new_id


### PR DESCRIPTION
If a submission is failed, the tool will check and adjust/resubmit again with a newly generated job_id. For GitHub Actions, this needs to be null again.

https://github.com/TheKevJames/coveralls-python/issues/252#issuecomment-783452375

<!--
Pull requests with untested code will not be merged right away; if you would like to speed up the review process, please write tests.

Please make sure your PR passes our CI requirements. You can run these locally with

    pre-commit run --all-files
    tox

If your work affects the public-facing API or usage of this project, please make sure to update the relevant documentation.
-->
