### PR TITLE
Push github actions coverage information from tags

### DIFF
--- a/coveralls/git.py
+++ b/coveralls/git.py
@@ -32,7 +32,10 @@ def git_branch():
     branch = None
     if os.environ.get('GITHUB_ACTIONS'):
         github_ref = os.environ.get('GITHUB_REF')
-        if github_ref.startswith('refs/heads/') or github_ref.startswith('refs/tags/'):
+        if (
+            github_ref.startswith('refs/heads/')
+            or github_ref.startswith('refs/tags/')
+        ):
             # E.g. in push events.
             branch = github_ref.split('/', 2)[-1]
         else:

--- a/coveralls/git.py
+++ b/coveralls/git.py
@@ -32,7 +32,7 @@ def git_branch():
     branch = None
     if os.environ.get('GITHUB_ACTIONS'):
         github_ref = os.environ.get('GITHUB_REF')
-        if github_ref.startswith('refs/heads/'):
+        if github_ref.startswith('refs/heads/') or github_ref.startswith('refs/tags/'):
             # E.g. in push events.
             branch = github_ref.split('/', 2)[-1]
         else:

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -125,7 +125,7 @@ class GitInfoTestBranch(GitTest):
         'GITHUB_SHA': 'bb0e00166b28f49db04d6a8b8cb4bddb5afa529f',
         'GITHUB_HEAD_REF': ''
     }, clear=True)
-    def test_gitinfo_github_nopr(self):
+    def test_gitinfo_github_branch(self):
         git_info = coveralls.git.git_info()
         assert git_info['git']['branch'] == 'master'
 
@@ -135,6 +135,6 @@ class GitInfoTestBranch(GitTest):
         'GITHUB_SHA': 'bb0e00166b28f49db04d6a8b8cb4bddb5afa529f',
         'GITHUB_HEAD_REF': ''
     }, clear=True)
-    def test_gitinfo_github_nopr(self):
+    def test_gitinfo_github_tag(self):
         git_info = coveralls.git.git_info()
         assert git_info['git']['branch'] == 'v1.0'

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -128,3 +128,13 @@ class GitInfoTestBranch(GitTest):
     def test_gitinfo_github_nopr(self):
         git_info = coveralls.git.git_info()
         assert git_info['git']['branch'] == 'master'
+
+    @mock.patch.dict(os.environ, {
+        'GITHUB_ACTIONS': 'true',
+        'GITHUB_REF': 'refs/tags/v1.0',
+        'GITHUB_SHA': 'bb0e00166b28f49db04d6a8b8cb4bddb5afa529f',
+        'GITHUB_HEAD_REF': ''
+    }, clear=True)
+    def test_gitinfo_github_nopr(self):
+        git_info = coveralls.git.git_info()
+        assert git_info['git']['branch'] == 'v1.0'


### PR DESCRIPTION
Modify the logic of getting the branch information to also be able to parse out the tag name when dealing with a tag push event on Github Actions.

<!--
Pull requests with untested code will not be merged right away; if you would like to speed up the review process, please write tests.

Please make sure your PR passes our CI requirements. You can run these locally with

    pre-commit run --all-files
    tox

If your work affects the public-facing API or usage of this project, please make sure to update the relevant documentation.
-->
