### PR TITLE
feat(api): support officially documented generic CI env vars (#299)

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -151,6 +151,9 @@ class Coveralls:
         # coveralls-ruby in lib/coveralls/configuration.rb
         # (set_standard_service_params_for_generic_ci)
 
+        # The meaning of each env var is clarified in:
+        # https://github.com/lemurheavy/coveralls-public/issues/1558
+
         config = {
             'service_name': os.environ.get('CI_NAME'),
             'service_number': os.environ.get('CI_BUILD_NUMBER'),

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -156,3 +156,27 @@ you can copy from the coveralls.io website).
 As per `#245 <https://github.com/TheKevJames/coveralls-python/issues/245>`_,
 our users suggest leaving "keep this value secret" unchecked -- this may be
 secure enough as-is, in that a user making a PR cannot access this variable.
+
+Other CI systems
+----------------
+
+As specified in the Coveralls `official docs
+<https://docs.coveralls.io/supported-ci-services>`
+other CI systems can be supported if the following environment variables are
+defined::
+
+    CI_NAME
+        # Name of the CI service being used
+    CI_BUILD_NUMBER
+        # Number (counter) relative to the current build
+    CI_BUILD_URL
+        # URL to a webpage showing the build information/output
+    CI_BRANCH
+        # For pull requests this is the name of the branch targeted by the PR,
+        # otherwise it corresponds to the name of the current branch or tag
+    CI_JOB_ID (optional)
+        # Unique identifier of the job in the CI service.
+        # When missing, CI_BUILD_NUMBER is used
+    CI_PULL_REQUEST (optional)
+        # If given, corresponds to the number of the pull request, as specified
+        # in the supported repository hosting service (GitHub, GitLab, etc)

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -166,18 +166,25 @@ other CI systems can be supported if the following environment variables are
 defined::
 
     CI_NAME
-        # Name of the CI service being used
+        # Name of the CI service being used.
     CI_BUILD_NUMBER
         # The number assigned to the build by your CI service.
     CI_BUILD_URL
-        # URL to a webpage showing the build information/logs
+        # URL to a webpage showing the build information/logs.
     CI_BRANCH
         # For pull requests this is the name of the branch being targeted,
-        # otherwise it corresponds to the name of the current branch or tag
+        # otherwise it corresponds to the name of the current branch or tag.
     CI_JOB_ID (optional)
         # For parallel builds, the number assigned to each job comprising the build.
         # When missing, Coveralls will assign an incrementing integer (1, 2, 3 ...).
         # This value should not change between multiple runs of the build.
     CI_PULL_REQUEST (optional)
         # If given, corresponds to the number of the pull request, as specified
-        # in the supported repository hosting service (GitHub, GitLab, etc)
+        # in the supported repository hosting service (GitHub, GitLab, etc).
+        # This variable expects a value defined as an integer, e.g.:
+        #   CI_PULL_REQUEST=42             (recommended)
+        # However, for flexibility, any single line string ending with the same
+        # integer value can also be used (such as the pull request URL or
+        # relative path), e.g.:
+        #   CI_PULL_REQUEST='myuser/myrepo/pull/42'
+        #   CI_PULL_REQUEST='https://github.com/myuser/myrepo/pull/42'

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -168,15 +168,16 @@ defined::
     CI_NAME
         # Name of the CI service being used
     CI_BUILD_NUMBER
-        # Number (counter) relative to the current build
+        # The number assigned to the build by your CI service.
     CI_BUILD_URL
-        # URL to a webpage showing the build information/output
+        # URL to a webpage showing the build information/logs
     CI_BRANCH
-        # For pull requests this is the name of the branch targeted by the PR,
+        # For pull requests this is the name of the branch being targeted,
         # otherwise it corresponds to the name of the current branch or tag
     CI_JOB_ID (optional)
-        # Unique identifier of the job in the CI service.
-        # When missing, CI_BUILD_NUMBER is used
+        # For parallel builds, the number assigned to each job comprising the build.
+        # When missing, Coveralls will assign an incrementing integer (1, 2, 3 ...).
+        # This value should not change between multiple runs of the build.
     CI_PULL_REQUEST (optional)
         # If given, corresponds to the number of the pull request, as specified
         # in the supported repository hosting service (GitHub, GitLab, etc)

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -198,6 +198,40 @@ class NoConfiguration(unittest.TestCase):
         assert cover.config['service_number'] == 'b86b3adf'
         assert cover.config['service_pull_request'] == '9999'
 
+    @mock.patch.dict(
+        os.environ,
+        {'CI_NAME': 'generic-ci',
+         'CI_PULL_REQUEST': 'pull/1234',
+         'CI_JOB_ID': 'bb0e00166',
+         'CI_BUILD_NUMBER': '3',
+         'CI_BUILD_URL': 'https://generic-ci.local/build/123456789',
+         'CI_BRANCH': 'fixup-branch',
+         'COVERALLS_REPO_TOKEN': 'xxx'},
+        clear=True)
+    def test_generic_no_config(self):
+        cover = Coveralls()
+        assert cover.config['service_name'] == 'generic-ci'
+        assert cover.config['service_job_id'] == 'bb0e00166'
+        assert cover.config['service_branch'] == 'fixup-branch'
+        assert cover.config['service_pull_request'] == '1234'
+
+    @mock.patch.dict(
+        os.environ,
+        {'CI_NAME': 'generic-ci',
+         'CI_PULL_REQUEST': '',
+         'CI_JOB_ID': 'bb0e00166',
+         'CI_BUILD_NUMBER': '3',
+         'CI_BUILD_URL': 'https://generic-ci.local/build/123456789',
+         'CI_BRANCH': 'fixup-branch',
+         'COVERALLS_REPO_TOKEN': 'xxx'},
+        clear=True)
+    def test_generic_no_config_no_pr(self):
+        cover = Coveralls()
+        assert cover.config['service_name'] == 'generic-ci'
+        assert cover.config['service_job_id'] == 'bb0e00166'
+        assert cover.config['service_branch'] == 'fixup-branch'
+        assert 'service_pull_request' not in cover.config
+
     @mock.patch.dict(os.environ, {'COVERALLS_SERVICE_NAME': 'xxx'}, clear=True)
     def test_service_name_from_env(self):
         cover = Coveralls(repo_token='yyy')


### PR DESCRIPTION
This PR is related to #299 and #256.

The official docs for Coveralls define a set of generic environment variables that once defined should support any CI environment: https://docs.coveralls.io/supported-ci-services (bottom of the page).

The changes implemented in this PR attempt to read those variables but allows the values to be overwritten by any CI-specific configuration currently supported. They were also inspired by the official client ([coveralls-ruby - lib/coveralls/configuration.rb -set_standard_service_params_for_generic_ci](https://github.com/lemurheavy/coveralls-ruby/blob/76bbd5f930ab66f4f9e85970c3ec46510072086d/lib/coveralls/configuration.rb#L116)).

On top of the automated tox and pre-commit, I also did a manual test (to make sure no coveralls API error was introduced) following the steps described bellow:

1. Run `coveralls debug` in [an existing project/CI](https://cirrus-ci.com/task/4946467958816768) and copied the printed JSON string
2. Add the following keys and associated values regarding a non-supported CI service (e.g. cirrus-ci) to the copied JSON:
     ```python
     service_name
     service_number
     service_build_url
     service_job_id
     service_branch
     service_pull_request
     repo_token
   ```
   which include all the configuration keys being used in the new function `load_config_generic_ci_environment`
3. Manually submit the modified JSON payload to `https://coveralls.io/api/v1/jobs`, using the requests library, using:
   ```python
   requests.post('https://coveralls.io/api/v1/jobs', files={'json_file': json.dumps(payload)}, 
   verify=False)
   ```

The `POST` request was successful  (200 return code), and the outcome can be observed in https://coveralls.io/builds/40277688, which seem to indicate that the changes do not introduce any non-supported payload key for the coveralls HTTP API (which was already expected since it mimics the official Ruby client implementation).

Please let me know of any feedback, I can also implement some changes if there is something that is not adequate.

A final observation about the changes in the docs: although the official webpage does not describe the meaning of each `CI_` environment variable, I managed to create some useful description by inspect both Ruby and Python clients and cross-correlating the environment variables for other services according to their documentation (e.g. Travis, Circle, GitLab, GitHub, Semaphore).