### PR TITLE
feat: add --srcdir option

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -371,7 +371,9 @@ class Coveralls:
         workman.get_data()
 
         base_dir = self.config.get('base_dir') or ''
-        return CoverallReporter(workman, workman.config, base_dir).coverage
+        src_dir = self.config.get('src_dir') or ''
+        return CoverallReporter(workman, workman.config, base_dir,
+                                src_dir).coverage
 
     @staticmethod
     def debug_bad_encoding(data):

--- a/coveralls/cli.py
+++ b/coveralls/cli.py
@@ -21,6 +21,7 @@ Global options:
     --rcfile=<file>   Specify configuration file. [default: .coveragerc]
     --basedir=<dir>   Base directory that is removed from reported paths.
     --output=<file>   Write report to file. Doesn't send anything.
+    --srcdir=<dir>    Source directory added to reported paths.
     --submit=<file>   Upload a previously generated file.
     --merge=<file>    Merge report from file when submitting.
     --finish          Finish parallel jobs.
@@ -63,7 +64,8 @@ def main(argv=None):
         coverallz = Coveralls(token_required,
                               config_file=options['--rcfile'],
                               service_name=options['--service'],
-                              base_dir=options.get('--basedir') or '')
+                              base_dir=options.get('--basedir') or '',
+                              src_dir=options.get('--srcdir') or '')
 
         if options['--merge']:
             coverallz.merge(options['--merge'])

--- a/coveralls/reporter.py
+++ b/coveralls/reporter.py
@@ -12,14 +12,19 @@ log = logging.getLogger('coveralls.reporter')
 class CoverallReporter:
     """Custom coverage.py reporter for coveralls.io."""
 
-    def __init__(self, cov, conf, base_dir=''):
+    def __init__(self, cov, conf, base_dir='', src_dir=''):
         self.coverage = []
-        self.base_dir = base_dir
-        if self.base_dir:
-            self.base_dir = self.base_dir.replace(os.path.sep, '/')
-            if self.base_dir[-1] != '/':
-                self.base_dir += '/'
+        self.base_dir = self.sanitize_dir(base_dir)
+        self.src_dir = self.sanitize_dir(src_dir)
         self.report(cov, conf)
+
+    @staticmethod
+    def sanitize_dir(directory):
+        if directory:
+            directory = directory.replace(os.path.sep, '/')
+            if directory[-1] != '/':
+                directory += '/'
+        return directory
 
     def report5(self, cov):
         # N.B. this method is 99% copied from the coverage source code;
@@ -194,6 +199,7 @@ class CoverallReporter:
 
         if self.base_dir and posix_filename.startswith(self.base_dir):
             posix_filename = posix_filename[len(self.base_dir):]
+        posix_filename = self.src_dir + posix_filename
 
         source = analysis.file_reporter.source()
 

--- a/tests/api/reporter_test.py
+++ b/tests/api/reporter_test.py
@@ -30,13 +30,9 @@ class ReporterTest(unittest.TestCase):
         except Exception:
             pass
 
-    def test_reporter(self):
-        subprocess.call(['coverage', 'run', '--omit=**/.tox/*',
-                         'runtests.py'], cwd=EXAMPLE_DIR)
-        results = Coveralls(repo_token='xxx').get_coverage()
-        assert len(results) == 2
-
-        assert_coverage(results[0], {
+    @staticmethod
+    def make_test_results(with_branches=False, name_prefix=''):
+        results = ({
             'source': ('def hello():\n'
                        '    print(\'world\')\n\n\n'
                        'class Foo:\n'
@@ -48,19 +44,32 @@ class ReporterTest(unittest.TestCase):
                        '        print(\'condition tested both ways\')\n'
                        '    if cond2:\n'
                        '        print(\'condition not tested both ways\')\n'),
-            'name': 'project.py',
+            'name': '{}project.py'.format(name_prefix),
             'coverage': [1, 1, None, None, 1, None, None,
-                         None, 1, 0, None, 1, 1, 1, 1, 1]})
-
-        assert_coverage(results[1], {
+                         None, 1, 0, None, 1, 1, 1, 1, 1]}, {
             'source': ('from project import branch\n'
                        'from project import hello\n\n'
                        "if __name__ == '__main__':\n"
                        '    hello()\n'
                        '    branch(False, True)\n'
                        '    branch(True, True)\n'),
-            'name': 'runtests.py',
+            'name': '{}runtests.py'.format(name_prefix),
             'coverage': [1, 1, None, 1, 1, 1, 1]})
+        if with_branches:
+            results[0]['branches'] = [13, 0, 14, 1, 13, 0, 15, 1, 15, 0, 16, 1,
+                                      15, 0, 12, 0]
+            results[1]['branches'] = [4, 0, 5, 1, 4, 0, 1, 0]
+        return results
+
+    def test_reporter(self):
+        subprocess.call(['coverage', 'run', '--omit=**/.tox/*',
+                         'runtests.py'], cwd=EXAMPLE_DIR)
+        results = Coveralls(repo_token='xxx').get_coverage()
+        assert len(results) == 2
+
+        expected_results = self.make_test_results()
+        assert_coverage(results[0], expected_results[0])
+        assert_coverage(results[1], expected_results[1])
 
     def test_reporter_no_base_dir_arg(self):
         subprocess.call(['coverage', 'run', '--omit=**/.tox/*',
@@ -71,31 +80,9 @@ class ReporterTest(unittest.TestCase):
         results = Coveralls(repo_token='xxx').get_coverage()
         assert len(results) == 2
 
-        assert_coverage(results[0], {
-            'source': ('def hello():\n'
-                       '    print(\'world\')\n\n\n'
-                       'class Foo:\n'
-                       '    """ Bar """\n\n\n'
-                       'def baz():\n'
-                       '    print(\'this is not tested\')\n\n'
-                       'def branch(cond1, cond2):\n'
-                       '    if cond1:\n'
-                       '        print(\'condition tested both ways\')\n'
-                       '    if cond2:\n'
-                       '        print(\'condition not tested both ways\')\n'),
-            'name': 'example/project.py',
-            'coverage': [1, 1, None, None, 1, None, None,
-                         None, 1, 0, None, 1, 1, 1, 1, 1]})
-
-        assert_coverage(results[1], {
-            'source': ('from project import branch\n'
-                       'from project import hello\n\n'
-                       "if __name__ == '__main__':\n"
-                       '    hello()\n'
-                       '    branch(False, True)\n'
-                       '    branch(True, True)\n'),
-            'name': 'example/runtests.py',
-            'coverage': [1, 1, None, 1, 1, 1, 1]})
+        expected_results = self.make_test_results(name_prefix='example/')
+        assert_coverage(results[0], expected_results[0])
+        assert_coverage(results[1], expected_results[1])
 
     def test_reporter_with_base_dir_arg(self):
         subprocess.call(['coverage', 'run', '--omit=**/.tox/*',
@@ -107,31 +94,9 @@ class ReporterTest(unittest.TestCase):
                             base_dir='example').get_coverage()
         assert len(results) == 2
 
-        assert_coverage(results[0], {
-            'source': ('def hello():\n'
-                       '    print(\'world\')\n\n\n'
-                       'class Foo:\n'
-                       '    """ Bar """\n\n\n'
-                       'def baz():\n'
-                       '    print(\'this is not tested\')\n\n'
-                       'def branch(cond1, cond2):\n'
-                       '    if cond1:\n'
-                       '        print(\'condition tested both ways\')\n'
-                       '    if cond2:\n'
-                       '        print(\'condition not tested both ways\')\n'),
-            'name': 'project.py',
-            'coverage': [1, 1, None, None, 1, None, None,
-                         None, 1, 0, None, 1, 1, 1, 1, 1]})
-
-        assert_coverage(results[1], {
-            'source': ('from project import branch\n'
-                       'from project import hello\n\n'
-                       "if __name__ == '__main__':\n"
-                       '    hello()\n'
-                       '    branch(False, True)\n'
-                       '    branch(True, True)\n'),
-            'name': 'runtests.py',
-            'coverage': [1, 1, None, 1, 1, 1, 1]})
+        expected_results = self.make_test_results()
+        assert_coverage(results[0], expected_results[0])
+        assert_coverage(results[1], expected_results[1])
 
     def test_reporter_with_base_dir_trailing_sep(self):
         subprocess.call(['coverage', 'run', '--omit=**/.tox/*',
@@ -143,31 +108,52 @@ class ReporterTest(unittest.TestCase):
                             base_dir='example/').get_coverage()
         assert len(results) == 2
 
-        assert_coverage(results[0], {
-            'source': ('def hello():\n'
-                       '    print(\'world\')\n\n\n'
-                       'class Foo:\n'
-                       '    """ Bar """\n\n\n'
-                       'def baz():\n'
-                       '    print(\'this is not tested\')\n\n'
-                       'def branch(cond1, cond2):\n'
-                       '    if cond1:\n'
-                       '        print(\'condition tested both ways\')\n'
-                       '    if cond2:\n'
-                       '        print(\'condition not tested both ways\')\n'),
-            'name': 'project.py',
-            'coverage': [1, 1, None, None, 1, None, None,
-                         None, 1, 0, None, 1, 1, 1, 1, 1]})
+        expected_results = self.make_test_results()
+        assert_coverage(results[0], expected_results[0])
+        assert_coverage(results[1], expected_results[1])
 
-        assert_coverage(results[1], {
-            'source': ('from project import branch\n'
-                       'from project import hello\n\n'
-                       "if __name__ == '__main__':\n"
-                       '    hello()\n'
-                       '    branch(False, True)\n'
-                       '    branch(True, True)\n'),
-            'name': 'runtests.py',
-            'coverage': [1, 1, None, 1, 1, 1, 1]})
+    def test_reporter_with_src_dir_arg(self):
+        subprocess.call(['coverage', 'run', '--omit=**/.tox/*',
+                         'example/runtests.py'], cwd=BASE_DIR)
+
+        # without base_dir arg, file name is prefixed with 'example/'
+        os.chdir(BASE_DIR)
+        results = Coveralls(repo_token='xxx',
+                            src_dir='src').get_coverage()
+        assert len(results) == 2
+
+        expected_results = self.make_test_results(name_prefix='src/example/')
+        assert_coverage(results[0], expected_results[0])
+        assert_coverage(results[1], expected_results[1])
+
+    def test_reporter_with_src_dir_trailing_sep(self):
+        subprocess.call(['coverage', 'run', '--omit=**/.tox/*',
+                         'example/runtests.py'], cwd=BASE_DIR)
+
+        # without base_dir arg, file name is prefixed with 'example/'
+        os.chdir(BASE_DIR)
+        results = Coveralls(repo_token='xxx',
+                            src_dir='src/').get_coverage()
+        assert len(results) == 2
+
+        expected_results = self.make_test_results(name_prefix='src/example/')
+        assert_coverage(results[0], expected_results[0])
+        assert_coverage(results[1], expected_results[1])
+
+    def test_reporter_with_both_base_dir_and_src_dir_args(self):
+        subprocess.call(['coverage', 'run', '--omit=**/.tox/*',
+                         'example/runtests.py'], cwd=BASE_DIR)
+
+        # without base_dir arg, file name is prefixed with 'example/'
+        os.chdir(BASE_DIR)
+        results = Coveralls(repo_token='xxx',
+                            base_dir='example',
+                            src_dir='src').get_coverage()
+        assert len(results) == 2
+
+        expected_results = self.make_test_results(name_prefix='src/')
+        assert_coverage(results[0], expected_results[0])
+        assert_coverage(results[1], expected_results[1])
 
     def test_reporter_with_branches(self):
         subprocess.call(['coverage', 'run', '--branch', '--omit=**/.tox/*',
@@ -179,34 +165,9 @@ class ReporterTest(unittest.TestCase):
         assert not len(results[0]['branches']) % 4
         assert not len(results[1]['branches']) % 4
 
-        assert_coverage(results[0], {
-            'source': ('def hello():\n'
-                       '    print(\'world\')\n\n\n'
-                       'class Foo:\n'
-                       '    """ Bar """\n\n\n'
-                       'def baz():\n'
-                       '    print(\'this is not tested\')\n\n'
-                       'def branch(cond1, cond2):\n'
-                       '    if cond1:\n'
-                       '        print(\'condition tested both ways\')\n'
-                       '    if cond2:\n'
-                       '        print(\'condition not tested both ways\')\n'),
-            'name': 'project.py',
-            'branches': [13, 0, 14, 1, 13, 0, 15, 1, 15, 0, 16, 1, 15, 0, 12,
-                         0],
-            'coverage': [1, 1, None, None, 1, None, None,
-                         None, 1, 0, None, 1, 1, 1, 1, 1]})
-
-        assert_coverage(results[1], {
-            'source': ('from project import branch\n'
-                       'from project import hello\n\n'
-                       "if __name__ == '__main__':\n"
-                       '    hello()\n'
-                       '    branch(False, True)\n'
-                       '    branch(True, True)\n'),
-            'name': 'runtests.py',
-            'branches': [4, 0, 5, 1, 4, 0, 1, 0],
-            'coverage': [1, 1, None, 1, 1, 1, 1]})
+        expected_results = self.make_test_results(with_branches=True)
+        assert_coverage(results[0], expected_results[0])
+        assert_coverage(results[1], expected_results[1])
 
     def test_missing_file(self):
         with open('extra.py', 'w') as f:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -109,7 +109,8 @@ def test_rcfile(mock_coveralls):
     coveralls.cli.main(argv=['--rcfile=coveragerc'])
     mock_coveralls.assert_called_with(True, config_file='coveragerc',
                                       service_name=None,
-                                      base_dir='')
+                                      base_dir='',
+                                      src_dir='')
 
 
 @mock.patch.dict(os.environ, {}, clear=True)
@@ -118,7 +119,8 @@ def test_service_name(mock_coveralls):
     coveralls.cli.main(argv=['--service=travis-pro'])
     mock_coveralls.assert_called_with(True, config_file='.coveragerc',
                                       service_name='travis-pro',
-                                      base_dir='')
+                                      base_dir='',
+                                      src_dir='')
 
 
 @mock.patch.object(coveralls.cli.log, 'exception')
@@ -164,4 +166,14 @@ def test_base_dir_arg(mock_coveralls):
     coveralls.cli.main(argv=['--basedir=foo'])
     mock_coveralls.assert_called_with(True, config_file='.coveragerc',
                                       service_name=None,
-                                      base_dir='foo')
+                                      base_dir='foo',
+                                      src_dir='')
+
+
+@mock.patch('coveralls.cli.Coveralls')
+def test_src_dir_arg(mock_coveralls):
+    coveralls.cli.main(argv=['--srcdir=foo'])
+    mock_coveralls.assert_called_with(True, config_file='.coveragerc',
+                                      service_name=None,
+                                      base_dir='',
+                                      src_dir='foo')


### PR DESCRIPTION
When the repository of Python project on GitHub has the structure
```
/myproject
    /src
        /myproject
            __init__.py
            somefile.py
    /docs
        ...
    /tests
        ...
    README.md
    tox.ini
    ...
```
and CI runs `tox` where `tox.ini` has set `usedevelop = false` and it runs tests with `pytest --cov=myproject --cov-report=term-missing tests`, where `myproject` refers to `myproject` package build and installed by `tox`, the coverage report will look like this:
```
----------- coverage: platform linux, python 3.6.8-final-0 -----------
Name                                                          Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------------------------
.tox/py36/lib/python3.6/site-packages/myproject/__init__.py       1      0   100%
.tox/py36/lib/python3.6/site-packages/myproject/somefile.py       2      0   100%
------------------------------------------------------------------------------------------------
TOTAL                                                             3      0   100%
```
The `.tox/py36/lib/python3.6/site-packages` can be stripped by recently introduced `--basedir` option. This pull request introduces `--srcdir` option that specify the package source directory after `--basedir` option is applied. With this feature, coveralls.io is able to display the content of project files correctly. To demonstrate it:
```bash
coveralls
```
reports the above coverage report to coveralls.io, but since `.tox/py36/lib/python3.6/site-packages/myproject/__init__.py` is not a valid path on GitHub, coveralls.io displays no coverage details for `__init__.py`. Running the coveralls as
```bash
coveralls --basedir=.tox/py36/lib/python3.6/site-packages --srcdir=src
```
do the trick and the coverage details for `__init__.py` are visible in coveralls.io web UI, since `src/myproject/__init__.py` is an existing path on GitHub repository.