### PR TITLE
tests(git): add test to cover not a git repository case

### DIFF
--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -8,7 +8,7 @@ import unittest
 from unittest import mock
 
 import coveralls.git
-
+from coveralls.exception import CoverallsException
 
 GIT_COMMIT_MSG = 'first commit'
 GIT_EMAIL = 'me@here.com'
@@ -106,6 +106,22 @@ class GitInfoTestEnvVars(unittest.TestCase):
                 'branch': 'master',
             },
         }
+
+
+class GitInfoTestNotAGitRepository(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+
+        os.chdir(self.dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.dir)
+
+    def test_gitlog_not_a_git_repo(self):
+        git_info = coveralls.git.git_info()
+
+        self.assertRaises(CoverallsException)
+        assert git_info == {}
 
 
 class GitInfoTestBranch(GitTest):


### PR DESCRIPTION
This PR adds a test to cover the folder is not a git repository corner case.

The only motive was to increase the coverage.
```
  coveralls/git.py            36      0     10      0   100%
```
:partying_face: 

<!--
Pull requests with untested code will not be merged right away; if you would like to speed up the review process, please write tests.

Please make sure your PR passes our CI requirements. You can run these locally with

    pre-commit run --all-files
    tox

If your work affects the public-facing API or usage of this project, please make sure to update the relevant documentation.
-->
