### PR TITLE
docs/configuration: Avoid over-exposing GITHUB_TOKEN

### DIFF
--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -121,10 +121,10 @@ parallel build is finished::
         runs-on: ubuntu-latest
         container: python:3-slim
         steps:
+        - name: Install coveralls
+          run: pip3 install --upgrade coveralls
         - name: Finished
-          run: |
-            pip3 install --upgrade coveralls
-            coveralls --service=github --finish
+          run: coveralls --service=github --finish
           env:
             GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The GITHUB_TOKEN in this example _should_ of course be just a read-only token but in any case secrets should not be exposed to code that does not need them. In this case pip does not need to authenticate to GitHub.