### PR TITLE
Support pyproject.toml (for coverage package configs) file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           condition: <<parameters.cov_version>>
           steps:
             - run: tox -f <<parameters.tox_environment>>
-            - run: tox -e coveralls41
+            - run: tox -e coveralls5
       - when:
           condition: <<parameters.cov_version>>
           steps:
@@ -65,35 +65,35 @@ workflows:
           tox_environment: py36
           matrix:
             parameters:
-              cov_version: ['41', '5', '6']
+              cov_version: ['5', '6']
       - toxpy:
           name: test-py3.7-cov<<matrix.cov_version>>
           docker_image: '3.7'
           tox_environment: py37
           matrix:
             parameters:
-              cov_version: ['41', '5', '6']
+              cov_version: ['5', '6']
       - toxpy:
           name: test-py3.8-cov<<matrix.cov_version>>
           docker_image: '3.8'
           tox_environment: py38
           matrix:
             parameters:
-              cov_version: ['41', '5', '6']
+              cov_version: ['5', '6']
       - toxpy:
           name: test-py3.9-cov<<matrix.cov_version>>
           docker_image: '3.9'
           tox_environment: py39
           matrix:
             parameters:
-              cov_version: ['41', '5', '6']
+              cov_version: ['5', '6']
       - toxpy:
           name: test-py3.10-cov<<matrix.cov_version>>
           docker_image: '3.10'
           tox_environment: py310
           matrix:
             parameters:
-              cov_version: ['41', '5', '6']
+              cov_version: ['5', '6']
 
   test-pypy:
     jobs:
@@ -101,11 +101,11 @@ workflows:
           name: test-pypy<<matrix.docker_image>>-cov<<matrix.cov_version>>
           matrix:
             parameters:
-              cov_version: ['41', '5']
+              cov_version: ['5']
               docker_image: ['3-5', '3-6']
       - toxpypy:
           name: test-pypy3-7-cov<<matrix.cov_version>>
           docker_image: '3-7'
           matrix:
             parameters:
-              cov_version: ['41', '5', '6']
+              cov_version: ['5', '6']

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     },
     python_requires='>= 3.5',
     install_requires=[
-        'coverage>=4.1,<7.0',
+        'coverage[toml]>=5.0<7.0',
         'docopt>=0.6.1',
         'requests>=1.0.0',
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35-cov41-{default,pyyaml},py{36,37,38,39,310,py3}-cov{41,5,6}-{default,pyyaml}
+envlist = py35-cov5-{default,pyyaml},py{36,37,38,39,310,py3}-cov{5,6}-{default,pyyaml}
 
 [gh-actions]
 python =
@@ -18,27 +18,20 @@ deps =
     responses
     pytest
     pyyaml: PyYAML>=3.10,<5.3
-    cov41: coverage>=4.1,<5.0
-    cov5: coverage>=5.0,<6.0
-    cov6: coverage>=6.0,<7.0
+    cov5: coverage[toml]>=5.0,<6.0
+    cov6: coverage[toml]>=6.0,<7.0
 commands =
     coverage run --branch --source=coveralls -m pytest tests/
     coverage report -m
 
-[testenv:coveralls41]
-deps =
-    coverage>=4.1,<5.0
-commands =
-    coveralls --verbose
-
 [testenv:coveralls5]
 deps =
-    coverage>=5.0,<6.0
+    coverage[toml]>=5.0,<6.0
 commands =
     coveralls --verbose
 
 [testenv:coveralls6]
 deps =
-    coverage>=6.0,<7.0
+    coverage[toml]>=6.0,<7.0
 commands =
     coveralls --verbose


### PR DESCRIPTION
I encountered the following error when I run `coveralls` with `coverage` settings written in a `pyproject.toml` file. This PR aims to fix the problem.

```
Submitting coverage to coveralls.io...
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.8.12/x64/bin/coveralls", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/coveralls/cli.py", line 95, in main
    result = coverallz.wear()
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/coveralls/api.py", line 252, in wear
    json_string = self.create_report()
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/coveralls/api.py", line 330, in create_report
    data = self.create_data()
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/coveralls/api.py", line 384, in create_data
    self._data = {'source_files': self.get_coverage()}
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/coveralls/api.py", line 398, in get_coverage
    workman = coverage.coverage(config_file=config_file)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/coverage/control.py", line 239, in __init__
    self.config = read_coverage_config(
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/coverage/config.py", line 545, in read_coverage_config
    config_read = config.from_file(fname, warn, our_file=our_file)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/coverage/config.py", line 273, in from_file
    files_read = cp.read(filename)
  File "/opt/hostedtoolcache/Python/3.8.12/x64/lib/python3.8/site-packages/coverage/tomlconfig.py", line 60, in read
    raise CoverageException(msg.format(filename))
coverage.exceptions.CoverageException: Can't read 'pyproject.toml' without TOML support. Install with [toml] extra
```

As the error message indicated, `coverage` is required to install with `[toml]` extra when you use `pyproject.toml` as a config file.

---
note: `toml` config file support was added at [coverage v5](https://coverage.readthedocs.io/en/latest/changes.html#version-5-0b1-2019-11-11).

