### PR TITLE
Fix support for parallel execution on CircleCI

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -97,7 +97,8 @@ class Coveralls:
 
     @staticmethod
     def load_config_from_circle():
-        number = os.environ.get('CIRCLE_WORKFLOW_ID') or os.environ.get('CIRCLE_BUILD_NUM')
+        number = os.environ.get(
+            'CIRCLE_WORKFLOW_ID') or os.environ.get('CIRCLE_BUILD_NUM')
         pr = (os.environ.get('CI_PULL_REQUEST') or "").split("/")[-1] or None
         job = os.environ.get('CIRCLE_NODE_INDEX') or None
         return 'circleci', job, number, pr

--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -97,9 +97,10 @@ class Coveralls:
 
     @staticmethod
     def load_config_from_circle():
-        pr = os.environ.get('CI_PULL_REQUEST', '').split('/')[-1] or None
-        number = os.environ.get('CIRCLE_WORKFLOW_ID')
-        return 'circle-ci', os.environ.get('CIRCLE_BUILD_NUM'), number, pr
+        number = os.environ.get('CIRCLE_WORKFLOW_ID') or os.environ.get('CIRCLE_BUILD_NUM')
+        pr = (os.environ.get('CI_PULL_REQUEST') or "").split("/")[-1] or None
+        job = os.environ.get('CIRCLE_NODE_INDEX') or None
+        return 'circleci', job, number, pr
 
     def load_config_from_github(self):
         # Github tokens and standard Coveralls tokens are almost but not quite

--- a/docs/usage/tox.rst
+++ b/docs/usage/tox.rst
@@ -52,8 +52,10 @@ CircleCI
 All variables:
 
 - ``CIRCLECI``
+- ``CIRCLE_WORKFLOW_ID``
 - ``CIRCLE_BUILD_NUM``
 - ``CIRCLE_BRANCH``
+- ``CIRCLE_NODE_INDEX``
 - ``CI_PULL_REQUEST``
 
 Github Actions

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -113,11 +113,23 @@ class NoConfiguration(unittest.TestCase):
          'CIRCLE_BUILD_NUM': '888',
          'CI_PULL_REQUEST': 'https://github.com/org/repo/pull/9999'},
         clear=True)
-    def test_circleci_no_config(self):
+    def test_circleci_singular_no_config(self):
         cover = Coveralls(repo_token='xxx')
-        assert cover.config['service_name'] == 'circle-ci'
-        assert cover.config['service_job_id'] == '888'
+        assert cover.config['service_name'] == 'circleci'
+        assert cover.config['service_number'] == '888'
         assert cover.config['service_pull_request'] == '9999'
+
+    @mock.patch.dict(
+        os.environ,
+        {'CIRCLECI': 'True',
+         'CIRCLE_WORKFLOW_ID': '0ea2c0f7-4e56-4a94-bf77-bfae6bdbf80a',
+         'CIRCLE_NODE_INDEX': '15'},
+        clear=True)
+    def test_circleci_parallel_no_config(self):
+        cover = Coveralls(repo_token='xxx')
+        assert cover.config['service_name'] == 'circleci'
+        assert cover.config['service_number'] == '0ea2c0f7-4e56-4a94-bf77-bfae6bdbf80a'
+        assert cover.config['service_job_id'] == '15'
 
     @mock.patch.dict(
         os.environ,


### PR DESCRIPTION
Support for parallel execution with CircleCI does not function as expected. With 16 parallel execution nodes followed by the parallel-complete webhook, the following result is seen on the Coveralls dashboard. Note the `.16` at the end, indicating that only the final node's coverage report was processed correctly.
<img width="1107" alt="Screen Shot 2021-11-10 at 9 52 46 AM" src="https://user-images.githubusercontent.com/91486640/141166921-4d6e70d4-b17c-46d1-96a6-0523424c1c23.png">

This PR makes a minor change to utilize the `CIRCLE_NODE_INDEX`, which is required for parallel execution support. This change mirrors the functionality from [coveralls-ruby](https://github.com/lemurheavy/coveralls-ruby/blob/6453624810be9862842874f0c812c7af45c5cadb/lib/coveralls/configuration.rb#L61).

Utilizing e26d574388db8e83dd93d6c84e6a79243a8b1d3f, subsequent runs yielded the expected results on the Coveralls dashboard.
<img width="1107" alt="Screen Shot 2021-11-10 at 9 53 06 AM" src="https://user-images.githubusercontent.com/91486640/141167641-6c4ff0f4-6f22-4039-9657-0e18da6300fd.png">

