### PR TITLE
fix(reporter: report5): FnmatchMatcher now require `name` argument

### DIFF
--- a/coveralls/reporter.py
+++ b/coveralls/reporter.py
@@ -68,12 +68,12 @@ class CoverallReporter:
         config = cov.config
 
         if config.report_include:
-            matcher = FnmatchMatcher(prep_patterns(config.report_include))
+            matcher = FnmatchMatcher(prep_patterns(config.report_include), name='coveralls')
             file_reporters = [fr for fr in file_reporters
                               if matcher.match(fr.filename)]
 
         if config.report_omit:
-            matcher = FnmatchMatcher(prep_patterns(config.report_omit))
+            matcher = FnmatchMatcher(prep_patterns(config.report_omit), name='coveralls')
             file_reporters = [fr for fr in file_reporters
                               if not matcher.match(fr.filename)]
 


### PR DESCRIPTION
in new version of `python-coverage` (ex. 6.1.1) `name` argument is required, so it's not possible to run the coveralls:

```console
$ COVERALLS_REPO_TOKEN=foo coveralls
Submitting coverage to coveralls.io...
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/coveralls/reporter.py", line 122, in report
    from coverage.report import Reporter  # pylint: disable=import-outside-toplevel
ImportError: cannot import name 'Reporter' from 'coverage.report' (/usr/lib/python3.10/site-packages/coverage/report.py)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/sbin/coveralls", line 33, in <module>
    sys.exit(load_entry_point('coveralls==3.3.0', 'console_scripts', 'coveralls')())
  File "/usr/lib/python3.10/site-packages/coveralls/cli.py", line 95, in main
    result = coverallz.wear()
  File "/usr/lib/python3.10/site-packages/coveralls/api.py", line 252, in wear
    json_string = self.create_report()
  File "/usr/lib/python3.10/site-packages/coveralls/api.py", line 330, in create_report
    data = self.create_data()
  File "/usr/lib/python3.10/site-packages/coveralls/api.py", line 384, in create_data
    self._data = {'source_files': self.get_coverage()}
  File "/usr/lib/python3.10/site-packages/coveralls/api.py", line 404, in get_coverage
    return CoverallReporter(workman, workman.config, base_dir,
  File "/usr/lib/python3.10/site-packages/coveralls/reporter.py", line 23, in __init__
    self.report(cov, conf)
  File "/usr/lib/python3.10/site-packages/coveralls/reporter.py", line 125, in report
    return self.report5(cov)
  File "/usr/lib/python3.10/site-packages/coveralls/reporter.py", line 76, in report5
    matcher = FnmatchMatcher(prep_patterns(config.report_omit))
TypeError: FnmatchMatcher.__init__() missing 1 required positional argument: 'name'
```

<!--
Pull requests with untested code will not be merged right away; if you would like to speed up the review process, please write tests.

Please make sure your PR passes our CI requirements. You can run these locally with

    pre-commit run --all-files
    tox

If your work affects the public-facing API or usage of this project, please make sure to update the relevant documentation.
-->
