### PR TITLE
Changed coveralls workflow to run Python 3.5/3.6 on ubuntu-20.04

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -4,11 +4,17 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
     strategy:
       max-parallel: 6
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
+        os: [ubuntu-latest]
+        include:
+        - python-version: '3.5'
+          os: ubuntu-20.04
+        - python-version: '3.6'
+          os: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Fixes issue #374 .
For details, see the commit message.