### PR TITLE
Avoid importing `unittest` twice

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+jobs:
+  analyze:
+    name: Analyze
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        queries: security-and-quality
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+        - python
+name: CodeQL
+'on':
+  push:
+    branches:
+    - master

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -1,7 +1,7 @@
 import os
 import tempfile
-import unittest
 from unittest import mock
+from unittest import TestCase
 
 import pytest
 try:
@@ -14,7 +14,7 @@ from coveralls.api import log
 
 
 @mock.patch.object(Coveralls, 'config_filename', '.coveralls.mock')
-class Configuration(unittest.TestCase):
+class Configuration(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.old_cwd = os.getcwd()
@@ -49,7 +49,7 @@ class Configuration(unittest.TestCase):
 
 
 @mock.patch.object(Coveralls, 'config_filename', '.coveralls.mock')
-class NoConfiguration(unittest.TestCase):
+class NoConfiguration(TestCase):
     @mock.patch.dict(os.environ, {'TRAVIS': 'True',
                                   'TRAVIS_JOB_ID': '777',
                                   'COVERALLS_REPO_TOKEN': 'yyy'}, clear=True)
@@ -269,7 +269,7 @@ class NoConfiguration(unittest.TestCase):
 
 
 @mock.patch.object(Coveralls, 'config_filename', '.coveralls.mock')
-class CLIConfiguration(unittest.TestCase):
+class CLIConfiguration(TestCase):
     def test_load_config(self):
         # pylint: disable=protected-access
         cover = Coveralls(

--- a/tests/api/wear_test.py
+++ b/tests/api/wear_test.py
@@ -1,8 +1,8 @@
 import json
 import os
 import tempfile
-import unittest
 from unittest import mock
+from unittest import TestCase
 
 import coverage
 import pytest
@@ -18,7 +18,7 @@ EXPECTED = {
 
 
 @mock.patch('coveralls.api.requests')
-class WearTest(unittest.TestCase):
+class WearTest(TestCase):
     def setUp(self):
         try:
             os.remove('.coverage')

--- a/tests/git_test.py
+++ b/tests/git_test.py
@@ -2,8 +2,8 @@ import os
 import re
 import subprocess
 import tempfile
-import unittest
 from unittest import mock
+from unittest import TestCase
 
 import coveralls.git
 from coveralls.exception import CoverallsException
@@ -15,7 +15,7 @@ GIT_REMOTE = 'origin'
 GIT_URL = 'https://github.com/username/Hello-World.git'
 
 
-class GitTest(unittest.TestCase):
+class GitTest(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.old_cwd = os.getcwd()
@@ -77,7 +77,7 @@ class GitLogTest(GitTest):
         assert coveralls.git.gitlog('%s') == GIT_COMMIT_MSG
 
 
-class GitInfoTest(unittest.TestCase):
+class GitInfoTest(TestCase):
     @classmethod
     def setUpClass(cls):
         cls.old_cwd = os.getcwd()
@@ -130,7 +130,7 @@ class GitInfoTest(unittest.TestCase):
         assert not git_info
 
 
-class GitInfoOverridesTest(unittest.TestCase):
+class GitInfoOverridesTest(TestCase):
     @mock.patch.dict(os.environ, {
         'GITHUB_ACTIONS': 'true',
         'GITHUB_REF': 'refs/pull/1234/merge',


### PR DESCRIPTION
From CodeQL:
```bash
Module 'unittest' is imported with both 'import' and 'import from'., which can prove to be confusing.
```
This PR changes nothing otherwise and should be more or less compatible.

<!--
Pull requests with untested code will not be merged right away; if you would like to speed up the review process, please write tests.

Please make sure your PR passes our CI requirements. You can run these locally with

    pre-commit run --all-files
    tox

If your work affects the public-facing API or usage of this project, please make sure to update the relevant documentation.
-->
