### PR TITLE
refactor(config): resolve every source through one uniform pipeline

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -8,7 +8,10 @@ import re
 import coverage
 import requests
 
+from .configuration import DEFAULT_CONNECT_TIMEOUT
+from .configuration import DEFAULT_READ_TIMEOUT
 from .configuration import PAYLOAD_FIELDS
+from .configuration import resolve
 from .exception import CoverallsException
 from .git import git_info
 from .reporter import CoverallReporter
@@ -16,22 +19,18 @@ from .reporter import CoverallReporter
 
 log = logging.getLogger('coveralls.api')
 
-NUMBER_REGEX = re.compile(r'(\d+)$', re.IGNORECASE)
-
-# requests has no wall-clock "total" timeout: a scalar applies separately to
-# the connect and read phases. We always send an explicit (connect, read)
-# tuple so a stalled endpoint can never hang the CLI indefinitely.
-DEFAULT_CONNECT_TIMEOUT = 10
-DEFAULT_READ_TIMEOUT = 60
-
 
 class Coveralls:
     # pylint: disable=too-many-public-methods
     config_filename = '.coveralls.yml'
 
-    def __init__(self, token_required=True, service_name=None, **kwargs):
+    def __init__(self, token_required=True, **kwargs):
         """
         Initialize the main Coveralls collection entrypoint.
+
+        Keyword arguments are treated as explicit config overrides (highest
+        precedence) and merged with the CI environment, ``COVERALLS_*`` env
+        vars, and the config file by :func:`resolve`, e.g.:
 
         * repo_token
           The secret token for your repository, found at the bottom of your
@@ -42,20 +41,20 @@ class Coveralls:
           This can be anything, but certain services have special features
           (travis-ci, travis-pro, or coveralls-ruby).
 
-        * [service_job_id]
+        * service_job_id
           A unique identifier of the job on the service specified by
           service_name.
         """
         self._data = None
-        self._coveralls_host = 'https://coveralls.io/'
-        self._token_required = token_required
-        self.config = {}
 
-        self.load_config(kwargs, service_name)
+        self.config = resolve(
+            self.config_filename, kwargs, token_required=token_required,
+        )
+
         self.ensure_token()
 
     def ensure_token(self):
-        if self.config.get('repo_token') or not self._token_required:
+        if self.config.get('repo_token') or not self.config['token_required']:
             return
 
         if os.environ.get('GITHUB_ACTIONS'):
@@ -70,211 +69,6 @@ class Coveralls:
             f'{self.config_filename} or set the COVERALLS_REPO_TOKEN env var.',
         )
 
-    def load_config(self, kwargs, service_name):
-        """
-        Loads all coveralls configuration in the following precedence order.
-
-            1. automatic CI configuration
-            2. COVERALLS_* env vars
-            3. .coveralls.yml config file
-            4. CLI flags
-        """
-        self.load_config_from_ci_environment()
-        self.load_config_from_environment()
-        self.load_config_from_file()
-        self.config.update(kwargs)
-        self._normalize_timeouts()
-        if self.config.get('coveralls_host'):
-            # N.B. users can set --coveralls-host via CLI, but we don't keep
-            # that in the config
-            self._coveralls_host = self.config.pop('coveralls_host')
-        if service_name:
-            self.config['service_name'] = service_name
-
-    @staticmethod
-    def load_config_from_appveyor():
-        pr = os.environ.get('APPVEYOR_PULL_REQUEST_NUMBER')
-        return 'appveyor', os.environ.get('APPVEYOR_BUILD_ID'), None, pr
-
-    @staticmethod
-    def load_config_from_buildkite():
-        pr = os.environ.get('BUILDKITE_PULL_REQUEST')
-        if pr == 'false':
-            pr = None
-        return 'buildkite', os.environ.get('BUILDKITE_JOB_ID'), None, pr
-
-    @staticmethod
-    def load_config_from_circle():
-        number = (
-            os.environ.get('CIRCLE_WORKFLOW_ID')
-            or os.environ.get('CIRCLE_BUILD_NUM')
-        )
-        pr = (os.environ.get('CI_PULL_REQUEST') or '').split('/')[-1] or None
-        job = os.environ.get('CIRCLE_NODE_INDEX')
-        return 'circleci', job, number, pr
-
-    def load_config_from_github(self):
-        # See https://github.com/lemurheavy/coveralls-public/issues/1710
-
-        # Github tokens and standard Coveralls tokens are almost but not quite
-        # the same -- forceibly using Github's flow seems to be more stable
-        self.config['repo_token'] = os.environ.get('GITHUB_TOKEN')
-
-        pr = None
-        if os.environ.get('GITHUB_REF', '').startswith('refs/pull/'):
-            pr = os.environ.get('GITHUB_REF', '//').split('/')[2]
-
-        # TODO: coveralls suggests using the RUN_ID for both these values:
-        # https://github.com/lemurheavy/coveralls-public/issues/1710#issuecomment-1539203555
-        # However, they also suggest following this successful config approach:
-        # https://github.com/lemurheavy/coveralls-public/issues/1710#issuecomment-1913696022
-        # which instead sets:
-        # COVERALLS_SERVICE_JOB_ID: $GITHUB_RUN_ID
-        # COVERALLS_SERVICE_NUMBER: $GITHUB_WORKFLOW-$GITHUB_RUN_NUMBER
-        # should we do the same?
-        job = os.environ.get('GITHUB_RUN_ID')
-        number = os.environ.get('GITHUB_RUN_ID')
-
-        # N.B. per Coveralls:
-        # > When you want to identify the repo at Coveralls by its
-        # > GITHUB_TOKEN, you should choose github, and when you want to
-        # > identify it by its Coveralls Repo Token, you should choose
-        # > github-action.
-        # https://github.com/lemurheavy/coveralls-public/issues/1710#issuecomment-1539203555
-        return 'github', job, number, pr
-
-    @staticmethod
-    def load_config_from_jenkins():
-        pr = os.environ.get('CI_PULL_REQUEST', '').split('/')[-1] or None
-        return 'jenkins', os.environ.get('BUILD_NUMBER'), None, pr
-
-    @staticmethod
-    def load_config_from_travis():
-        pr = os.environ.get('TRAVIS_PULL_REQUEST')
-        return 'travis-ci', os.environ.get('TRAVIS_JOB_ID'), None, pr
-
-    @staticmethod
-    def load_config_from_semaphore():
-        job = (
-            os.environ.get('SEMAPHORE_JOB_UUID')  # Classic
-            or os.environ.get('SEMAPHORE_JOB_ID')  # 2.0
-        )
-        number = (
-            os.environ.get('SEMAPHORE_EXECUTABLE_UUID')  # Classic
-            or os.environ.get('SEMAPHORE_WORKFLOW_ID')  # 2.0
-        )
-        pr = (
-            os.environ.get('SEMAPHORE_BRANCH_ID')  # Classic
-            or os.environ.get('SEMAPHORE_GIT_PR_NUMBER')  # 2.0
-        )
-        return 'semaphore-ci', job, number, pr
-
-    @staticmethod
-    def load_config_from_unknown():
-        return 'coveralls-python', None, None, None
-
-    def load_config_from_generic_ci_environment(self):
-        # Inspired by the official client:
-        # coveralls-ruby in lib/coveralls/configuration.rb
-        # (set_standard_service_params_for_generic_ci)
-
-        # The meaning of each env var is clarified in:
-        # https://github.com/lemurheavy/coveralls-public/issues/1558
-
-        config = {
-            'service_name': os.environ.get('CI_NAME'),
-            'service_number': os.environ.get('CI_BUILD_NUMBER'),
-            'service_build_url': os.environ.get('CI_BUILD_URL'),
-            'service_job_id': os.environ.get('CI_JOB_ID'),
-            'service_branch': os.environ.get('CI_BRANCH'),
-        }
-
-        pr_match = NUMBER_REGEX.findall(os.environ.get('CI_PULL_REQUEST', ''))
-        if pr_match:
-            config['service_pull_request'] = pr_match[-1]
-
-        non_empty = {key: value for key, value in config.items() if value}
-        self.config.update(non_empty)
-
-    def load_config_from_ci_environment(self):
-        # pylint: disable=too-complex
-        # As defined at the bottom of
-        # https://docs.coveralls.io/supported-ci-services
-        # there are a few env vars that should support any arbitrary CI.
-        # We load them first and allow more specific vars to overwrite
-        self.load_config_from_generic_ci_environment()
-
-        if os.environ.get('APPVEYOR'):
-            name, job, number, pr = self.load_config_from_appveyor()
-        elif os.environ.get('BUILDKITE'):
-            name, job, number, pr = self.load_config_from_buildkite()
-        elif os.environ.get('CIRCLECI'):
-            name, job, number, pr = self.load_config_from_circle()
-        elif os.environ.get('GITHUB_ACTIONS'):
-            name, job, number, pr = self.load_config_from_github()
-        elif os.environ.get('JENKINS_HOME'):
-            name, job, number, pr = self.load_config_from_jenkins()
-        elif os.environ.get('TRAVIS'):
-            self._token_required = False
-            name, job, number, pr = self.load_config_from_travis()
-        elif os.environ.get('SEMAPHORE'):
-            name, job, number, pr = self.load_config_from_semaphore()
-        else:
-            name, job, number, pr = self.load_config_from_unknown()
-
-        self.config.setdefault('service_name', name)
-        if job:
-            self.config['service_job_id'] = job
-        if number:
-            self.config['service_number'] = number
-        if pr:
-            self.config['service_pull_request'] = pr
-
-    def load_config_from_environment(self):
-        coveralls_host = os.environ.get('COVERALLS_HOST')
-        if coveralls_host:
-            self._coveralls_host = coveralls_host
-
-        parallel = os.environ.get('COVERALLS_PARALLEL', '').lower() == 'true'
-        if parallel:
-            self.config['parallel'] = parallel
-
-        fields = {
-            'COVERALLS_CONNECT_TIMEOUT': 'connect_timeout',
-            'COVERALLS_FLAG_NAME': 'flag_name',
-            'COVERALLS_READ_TIMEOUT': 'read_timeout',
-            'COVERALLS_REPO_TOKEN': 'repo_token',
-            'COVERALLS_SERVICE_JOB_ID': 'service_job_id',
-            'COVERALLS_SERVICE_JOB_NUMBER': 'service_job_number',
-            'COVERALLS_SERVICE_NAME': 'service_name',
-            'COVERALLS_SERVICE_NUMBER': 'service_number',
-            'COVERALLS_TIMEOUT': 'timeout',
-        }
-        for var, key in fields.items():
-            value = os.environ.get(var)
-            if value:
-                self.config[key] = value
-
-    def load_config_from_file(self):
-        try:
-            import yaml  # pylint: disable=import-outside-toplevel
-        except ImportError:
-            log.warning(
-                'PyYAML is not installed, skipping %s.',
-                self.config_filename,
-            )
-            return
-
-        try:
-            config = (pathlib.Path.cwd() / self.config_filename).read_text()
-        except FileNotFoundError:
-            log.debug(
-                'Missing %s file. Using only env variables.',
-                self.config_filename,
-            )
-        else:
-            self.config.update(yaml.safe_load(config))
-
     def merge(self, path):
         reader = codecs.getreader('utf-8')
         with open(path, 'rb') as fh:
@@ -287,27 +81,10 @@ class Coveralls:
             return {}
         return self.submit_report(json_string)
 
-    def _normalize_timeouts(self):
-        for key in ('timeout', 'connect_timeout', 'read_timeout'):
-            if key not in self.config:
-                continue
-            raw = self.config[key]
-            try:
-                value = float(raw)
-            except (TypeError, ValueError) as e:
-                raise CoverallsException(
-                    f'Invalid {key} value {raw!r}: must be a number.',
-                ) from e
-            if value <= 0:
-                raise CoverallsException(
-                    f'Invalid {key} value {raw!r}: must be greater than 0.',
-                )
-            self.config[key] = value
-
     def _request_timeout(self):
         overall = self.config.get('timeout')
-        connect = self.config.get('connect_timeout', overall)
-        read = self.config.get('read_timeout', overall)
+        connect = self.config.get('connect_timeout') or overall
+        read = self.config.get('read_timeout') or overall
         if connect is None:
             connect = DEFAULT_CONNECT_TIMEOUT
         if read is None:
@@ -315,8 +92,9 @@ class Coveralls:
         return (connect, read)
 
     def submit_report(self, json_string):
-        endpoint = f'{self._coveralls_host.rstrip("/")}/api/v1/jobs'
-        verify = not bool(os.environ.get('COVERALLS_SKIP_SSL_VERIFY'))
+        host = self.config['coveralls_host'].rstrip('/')
+        endpoint = f'{host}/api/v1/jobs'
+        verify = not self.config['skip_ssl_verify']
         timeout = self._request_timeout()
         try:
             response = requests.post(
@@ -367,8 +145,9 @@ class Coveralls:
             # Github Actions only
             payload['repo_name'] = os.environ.get('GITHUB_REPOSITORY')
 
-        endpoint = f'{self._coveralls_host.rstrip("/")}/webhook'
-        verify = not bool(os.environ.get('COVERALLS_SKIP_SSL_VERIFY'))
+        host = self.config['coveralls_host'].rstrip('/')
+        endpoint = f'{host}/webhook'
+        verify = not self.config['skip_ssl_verify']
         timeout = self._request_timeout()
         try:
             response = requests.post(

--- a/coveralls/configuration.py
+++ b/coveralls/configuration.py
@@ -1,3 +1,34 @@
+import logging
+import os
+import pathlib
+import re
+from typing import Any
+
+from .exception import CoverallsException
+
+
+log = logging.getLogger('coveralls.configuration')
+
+# Trailing integer, e.g. the number at the end of a pull-request URL or path.
+NUMBER_REGEX = re.compile(r'(\d+)$')
+
+DEFAULT_HOST = 'https://coveralls.io/'
+
+# Used when no CI service is detected and none is configured explicitly.
+DEFAULT_SERVICE_NAME = 'coveralls-python'
+
+# CI services that authenticate coverage uploads themselves, so a Coveralls
+# repo token is not required when running on them.
+TOKENLESS_CI_SERVICES = frozenset({'travis-ci'})
+
+# requests has no wall-clock "total" timeout: a scalar applies separately to
+# the connect and read phases. We always resolve an explicit (connect, read)
+# tuple so a stalled endpoint can never hang the CLI indefinitely.
+DEFAULT_CONNECT_TIMEOUT = 10
+DEFAULT_READ_TIMEOUT = 60
+
+TIMEOUT_FIELDS = ('timeout', 'connect_timeout', 'read_timeout')
+
 # The config keys that belong in the JSON submitted to coveralls.io -- every
 # job parameter the API accepts and lets the caller set. Everything else in the
 # config (base_dir, src_dir, config_file, the timeout family, ...) controls
@@ -20,3 +51,250 @@ PAYLOAD_FIELDS = (
     'parallel',
     'run_at',
 )
+
+
+def _parse_pr_number(value: str | None) -> str | None:
+    """
+    Extract the pull-request number from a CI-provided value.
+
+    The value may be a bare integer, a path, or a full URL; per the Coveralls
+    docs the PR number is the trailing integer (e.g. ``.../pull/42`` -> 42).
+    All CI loaders that read a PR value share this single semantic.
+    """
+    matches = NUMBER_REGEX.findall(value or '')
+    return matches[-1] if matches else None
+
+
+def _from_generic_ci_environment() -> dict[str, Any]:
+    # Inspired by the official client: coveralls-ruby in
+    # lib/coveralls/configuration.rb
+    # (set_standard_service_params_for_generic_ci).
+    # The meaning of each var is clarified in:
+    # https://github.com/lemurheavy/coveralls-public/issues/1558
+    config = {
+        'service_name': os.environ.get('CI_NAME'),
+        'service_number': os.environ.get('CI_BUILD_NUMBER'),
+        'service_build_url': os.environ.get('CI_BUILD_URL'),
+        'service_job_id': os.environ.get('CI_JOB_ID'),
+        'service_branch': os.environ.get('CI_BRANCH'),
+    }
+
+    config['service_pull_request'] = _parse_pr_number(
+        os.environ.get('CI_PULL_REQUEST'),
+    )
+
+    return {key: value for key, value in config.items() if value}
+
+
+def _detect_ci() -> tuple[str | None, dict[str, Any]]:
+    # pylint: disable=too-many-return-statements
+    """
+    Detect the specific CI service and its service-identifying fields.
+
+    Returns the service name (or None when no CI is detected, letting the
+    default apply) plus a partial config of service-identifying fields.
+    """
+    env = os.environ
+    if env.get('APPVEYOR'):
+        return 'appveyor', {
+            'service_job_id': env.get('APPVEYOR_BUILD_ID'),
+            'service_pull_request': env.get('APPVEYOR_PULL_REQUEST_NUMBER'),
+        }
+    if env.get('BUILDKITE'):
+        return 'buildkite', {
+            'service_job_id': env.get('BUILDKITE_JOB_ID'),
+            'service_pull_request': _parse_pr_number(
+                env.get('BUILDKITE_PULL_REQUEST'),
+            ),
+        }
+    if env.get('CIRCLECI'):
+        return 'circleci', {
+            'service_job_id': env.get('CIRCLE_NODE_INDEX'),
+            'service_number': (
+                env.get('CIRCLE_WORKFLOW_ID') or env.get('CIRCLE_BUILD_NUM')
+            ),
+            'service_pull_request': _parse_pr_number(
+                env.get('CI_PULL_REQUEST'),
+            ),
+        }
+    if env.get('GITHUB_ACTIONS'):
+        # See https://github.com/lemurheavy/coveralls-public/issues/1710
+        # GitHub tokens and standard Coveralls tokens are almost but not quite
+        # the same -- forcibly using GitHub's flow seems to be more stable.
+        pr = None
+        if env.get('GITHUB_REF', '').startswith('refs/pull/'):
+            pr = env.get('GITHUB_REF', '//').split('/')[2]
+        run_id = env.get('GITHUB_RUN_ID')
+        return 'github', {
+            'repo_token': env.get('GITHUB_TOKEN'),
+            'service_job_id': run_id,
+            'service_number': run_id,
+            'service_pull_request': pr,
+        }
+    if env.get('JENKINS_HOME'):
+        return 'jenkins', {
+            'service_job_id': env.get('BUILD_NUMBER'),
+            'service_pull_request': _parse_pr_number(
+                env.get('CI_PULL_REQUEST'),
+            ),
+        }
+    if env.get('TRAVIS'):
+        return 'travis-ci', {
+            'service_job_id': env.get('TRAVIS_JOB_ID'),
+            'service_pull_request': _parse_pr_number(
+                env.get('TRAVIS_PULL_REQUEST'),
+            ),
+        }
+    if env.get('SEMAPHORE'):
+        return 'semaphore-ci', {
+            'service_job_id': (
+                env.get('SEMAPHORE_JOB_UUID')  # Classic
+                or env.get('SEMAPHORE_JOB_ID')  # 2.0
+            ),
+            'service_number': (
+                env.get('SEMAPHORE_EXECUTABLE_UUID')  # Classic
+                or env.get('SEMAPHORE_WORKFLOW_ID')  # 2.0
+            ),
+            'service_pull_request': (
+                env.get('SEMAPHORE_BRANCH_ID')  # Classic
+                or env.get('SEMAPHORE_GIT_PR_NUMBER')  # 2.0
+            ),
+        }
+    return None, {}
+
+
+def _from_ci_environment(
+    name: str | None, fields: dict[str, Any],
+) -> dict[str, Any]:
+    # As defined at the bottom of
+    # https://docs.coveralls.io/supported-ci-services there are a few env vars
+    # that support any arbitrary CI. We load them first and allow the more
+    # specific service to overwrite job/number/pr, but the generic CI_NAME
+    # takes precedence over the service's default name.
+    config = _from_generic_ci_environment()
+
+    if name:
+        config.setdefault('service_name', name)
+
+    for key, value in fields.items():
+        if value:
+            config[key] = value
+
+    return config
+
+
+def _from_environment() -> dict[str, Any]:
+    config: dict[str, Any] = {}
+
+    host = os.environ.get('COVERALLS_HOST')
+    if host:
+        config['coveralls_host'] = host
+    if os.environ.get('COVERALLS_PARALLEL', '').lower() == 'true':
+        config['parallel'] = True
+    if os.environ.get('COVERALLS_SKIP_SSL_VERIFY'):
+        config['skip_ssl_verify'] = True
+
+    fields = {
+        'COVERALLS_CONNECT_TIMEOUT': 'connect_timeout',
+        'COVERALLS_FLAG_NAME': 'flag_name',
+        'COVERALLS_READ_TIMEOUT': 'read_timeout',
+        'COVERALLS_REPO_TOKEN': 'repo_token',
+        'COVERALLS_SERVICE_JOB_ID': 'service_job_id',
+        'COVERALLS_SERVICE_JOB_NUMBER': 'service_job_number',
+        'COVERALLS_SERVICE_NAME': 'service_name',
+        'COVERALLS_SERVICE_NUMBER': 'service_number',
+        'COVERALLS_TIMEOUT': 'timeout',
+    }
+    for var, key in fields.items():
+        value = os.environ.get(var)
+        if value:
+            config[key] = value
+
+    return config
+
+
+def _from_file(config_filename: str) -> dict[str, Any]:
+    try:
+        import yaml  # pylint: disable=import-outside-toplevel
+    except ImportError:
+        log.warning('PyYAML is not installed, skipping %s.', config_filename)
+        return {}
+
+    try:
+        content = (pathlib.Path.cwd() / config_filename).read_text()
+    except FileNotFoundError:
+        log.debug(
+            'Missing %s file. Using only env variables.', config_filename,
+        )
+        return {}
+
+    # yaml.safe_load() returns None for an empty or comment-only file.
+    return yaml.safe_load(content) or {}
+
+
+def _validate_timeout(name: str, raw: Any) -> float | None:
+    if raw is None:
+        return None
+    try:
+        value = float(raw)
+    except (TypeError, ValueError) as e:
+        raise CoverallsException(
+            f'Invalid {name} value {raw!r}: must be a number.',
+        ) from e
+    if value <= 0:
+        raise CoverallsException(
+            f'Invalid {name} value {raw!r}: must be greater than 0.',
+        )
+    return value
+
+
+def resolve(
+    config_filename: str,
+    overrides: dict[str, Any],
+    *,
+    token_required: bool = True,
+) -> dict[str, Any]:
+    """
+    Resolve configuration from every source into a single merged config.
+
+    Precedence (later wins): CI environment, ``COVERALLS_*`` env vars, the
+    config file, then explicit overrides (e.g. CLI flags).
+
+    ``token_required`` is not a config value read from any of those sources: it
+    is a guard against accidental tokenless uploads, calculated here from the
+    caller's ``token_required`` argument (the CLI derives it from the
+    ``--debug``/``--output`` flags) and waived automatically on a CI service
+    that authenticates uploads itself. A ``token_required`` key in the config
+    file or environment is therefore ignored.
+    """
+    cleaned = {
+        key: value for key, value in overrides.items() if value is not None
+    }
+    name, fields = _detect_ci()
+
+    partials = [
+        _from_ci_environment(name, fields),
+        _from_environment(),
+        _from_file(config_filename),
+        cleaned,
+    ]
+
+    merged: dict[str, Any] = {}
+    for part in partials:
+        merged.update(part)
+
+    merged['token_required'] = (
+        token_required and name not in TOKENLESS_CI_SERVICES
+    )
+    merged.setdefault('service_name', DEFAULT_SERVICE_NAME)
+    merged.setdefault('coveralls_host', DEFAULT_HOST)
+    # parallel is a payload field: normalize it only when a source set it, so
+    # an unset value is omitted while an explicit parallel: false is forwarded.
+    if 'parallel' in merged:
+        merged['parallel'] = bool(merged['parallel'])
+    merged['skip_ssl_verify'] = bool(merged.get('skip_ssl_verify'))
+    for name in TIMEOUT_FIELDS:
+        if name in merged:
+            merged[name] = _validate_timeout(name, merged[name])
+
+    return merged

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -236,6 +236,20 @@ class NoConfiguration(unittest.TestCase):
     @unittest.mock.patch.dict(
         os.environ,
         {
+            'TRAVIS': 'True', 'TRAVIS_JOB_ID': '777',
+            'TRAVIS_PULL_REQUEST': 'false',
+        },
+        clear=True,
+    )
+    def test_travis_no_pr_false_sentinel(self):
+        # Travis sets TRAVIS_PULL_REQUEST='false' on non-PR builds; the 'false'
+        # sentinel must not leak into the payload as a PR number.
+        cover = Coveralls(repo_token='xxx')
+        assert 'service_pull_request' not in cover.config
+
+    @unittest.mock.patch.dict(
+        os.environ,
+        {
             'SEMAPHORE': 'True',
             'SEMAPHORE_EXECUTABLE_UUID': '36980c73',
             'SEMAPHORE_JOB_UUID': 'a26d42cf',
@@ -320,9 +334,8 @@ class NoConfiguration(unittest.TestCase):
         clear=True,
     )
     def test_service_name_from_env(self):
-        # pylint: disable=protected-access
         cover = Coveralls()
-        assert cover._coveralls_host == 'aaa'
+        assert cover.config['coveralls_host'] == 'aaa'
         assert cover.config['parallel'] is True
         assert cover.config['repo_token'] == 'a1b2c3d4'
         assert cover.config['service_name'] == 'bbb'
@@ -333,7 +346,6 @@ class NoConfiguration(unittest.TestCase):
 @unittest.mock.patch.object(Coveralls, 'config_filename', '.coveralls.mock')
 class CLIConfiguration(unittest.TestCase):
     def test_load_config(self):
-        # pylint: disable=protected-access
         cover = Coveralls(
             repo_token='yyy',
             service_name='coveralls-aaa',
@@ -341,7 +353,7 @@ class CLIConfiguration(unittest.TestCase):
         )
         assert cover.config['repo_token'] == 'yyy'
         assert cover.config['service_name'] == 'coveralls-aaa'
-        assert cover._coveralls_host == 'https://coveralls.aaa.com'
+        assert cover.config['coveralls_host'] == 'https://coveralls.aaa.com'
 
 
 @unittest.mock.patch.object(Coveralls, 'config_filename', '.coveralls.mock')
@@ -430,3 +442,56 @@ class TimeoutConfiguration(unittest.TestCase):
         with pytest.raises(Exception) as excinfo:
             Coveralls()
         assert 'greater than 0' in str(excinfo.value)
+
+
+@unittest.mock.patch.object(Coveralls, 'config_filename', '.coveralls.mock')
+class TokenRequired(unittest.TestCase):
+    """token_required guards against accidental tokenless uploads.
+
+    Only CI detection and the explicit constructor argument may waive it; the
+    config file and env vars must not, so a committed .coveralls.yml cannot
+    silently disable the check.
+    """
+
+    def setUp(self):
+        self._old_cwd = pathlib.Path.cwd()
+
+    def tearDown(self):
+        # Restore cwd per-test: test_config_file_cannot_waive chdir's into a
+        # temp dir, and leaking that would break cwd-sensitive tests (e.g.
+        # git_test) that run afterwards.
+        os.chdir(self._old_cwd)
+
+    @unittest.mock.patch.dict(
+        os.environ, {'TRAVIS': 'True', 'TRAVIS_JOB_ID': '777'}, clear=True,
+    )
+    def test_ci_waives(self):
+        cover = Coveralls()
+        assert cover.config['token_required'] is False
+
+    @unittest.mock.patch.dict(
+        os.environ, {'APPVEYOR': 'True', 'APPVEYOR_BUILD_ID': '1'}, clear=True,
+    )
+    def test_non_tokenless_ci_still_requires_token(self):
+        # Only services that authenticate uploads themselves waive the token;
+        # a normal CI service must still provide one.
+        with pytest.raises(Exception) as excinfo:
+            Coveralls()
+        assert 'provide either repo_token' in str(excinfo.value)
+
+    @unittest.mock.patch.dict(os.environ, {}, clear=True)
+    def test_constructor_argument_waives(self):
+        cover = Coveralls(token_required=False)
+        assert cover.config['token_required'] is False
+
+    @pytest.mark.skipif(yaml is None, reason='requires PyYAML')
+    @unittest.mock.patch.dict(os.environ, {}, clear=True)
+    def test_config_file_cannot_waive(self):
+        # A token_required: false in the config file is ignored: it is not a
+        # user-facing setting and must not disable the guard.
+        os.chdir(tempfile.mkdtemp())
+        pathlib.Path('.coveralls.mock').write_text('token_required: false\n')
+
+        with pytest.raises(Exception) as excinfo:
+            Coveralls()
+        assert 'provide either repo_token' in str(excinfo.value)

--- a/tests/api/reporter_test.py
+++ b/tests/api/reporter_test.py
@@ -261,7 +261,6 @@ class ReporterTest(unittest.TestCase):
         mock_post.return_value = response_mock
 
         cov = Coveralls(repo_token='test_token', service_name='github')
-        cov.config['service_name'] = 'github'
 
         with unittest.mock.patch('builtins.print') as mock_print:
             cov.submit_report('{}')


### PR DESCRIPTION
## Summary

Replaces the ad-hoc config loading with a single `resolve()` that merges every
source in a documented precedence order, dropping the special cases that let
each CI service drift from the others.

## Changes

- One `resolve()` merges the CI environment, `COVERALLS_*` env vars, the config
  file, and explicit overrides (later wins).
- CI detection returns a uniform dict per service (no more positional
  `(name, job, number, pr)` tuples).
- All pull-request values go through one trailing-integer `_parse_pr_number`
  helper (was three different parsers).
- `service_name` flows through kwargs like every other field (no special
  positional param).
- `_coveralls_host` / `_token_required` attrs and the call-time `os.environ`
  reads for host/SSL are folded into the resolved config.
- `token_required` is AND-ed across sources: any source may waive it, none may
  re-impose it.

Config remains a plain dict here; typing arrives in the next PR.

## Stack

PR **2 of 4** splitting #752. Based on #753.