### PR TITLE
refactor(config): model resolved configuration as a typed Config

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -8,9 +8,7 @@ import re
 import coverage
 import requests
 
-from .configuration import DEFAULT_CONNECT_TIMEOUT
-from .configuration import DEFAULT_READ_TIMEOUT
-from .configuration import PAYLOAD_FIELDS
+from .configuration import Config
 from .configuration import resolve
 from .exception import CoverallsException
 from .git import git_info
@@ -47,14 +45,14 @@ class Coveralls:
         """
         self._data = None
 
-        self.config = resolve(
+        self.config: Config = resolve(
             self.config_filename, kwargs, token_required=token_required,
         )
 
         self.ensure_token()
 
     def ensure_token(self):
-        if self.config.get('repo_token') or not self.config['token_required']:
+        if self.config.repo_token or not self.config.token_required:
             return
 
         if os.environ.get('GITHUB_ACTIONS'):
@@ -81,21 +79,11 @@ class Coveralls:
             return {}
         return self.submit_report(json_string)
 
-    def _request_timeout(self):
-        overall = self.config.get('timeout')
-        connect = self.config.get('connect_timeout') or overall
-        read = self.config.get('read_timeout') or overall
-        if connect is None:
-            connect = DEFAULT_CONNECT_TIMEOUT
-        if read is None:
-            read = DEFAULT_READ_TIMEOUT
-        return (connect, read)
-
     def submit_report(self, json_string):
-        host = self.config['coveralls_host'].rstrip('/')
+        host = self.config.coveralls_host.rstrip('/')
         endpoint = f'{host}/api/v1/jobs'
-        verify = not self.config['skip_ssl_verify']
-        timeout = self._request_timeout()
+        verify = not self.config.skip_ssl_verify
+        timeout = self.config.request_timeout
         try:
             response = requests.post(
                 endpoint, files={'json_file': json_string}, verify=verify,
@@ -108,7 +96,7 @@ class Coveralls:
             ) from e
 
         if response.status_code == 422:
-            if self.config['service_name'].startswith('github'):
+            if self.config.service_name.startswith('github'):
                 print(
                     'Received 422 submitting job via Github Actions. By '
                     'default, coveralls-python uses the "github" service '
@@ -135,20 +123,20 @@ class Coveralls:
         payload = {'payload': {'status': 'done'}}
 
         # required args
-        if self.config.get('repo_token'):
-            payload['repo_token'] = self.config['repo_token']
-        if self.config.get('service_number'):
-            payload['payload']['build_num'] = self.config['service_number']
+        if self.config.repo_token:
+            payload['repo_token'] = self.config.repo_token
+        if self.config.service_number:
+            payload['payload']['build_num'] = self.config.service_number
 
         # service-specific parameters
         if os.environ.get('GITHUB_REPOSITORY'):
             # Github Actions only
             payload['repo_name'] = os.environ.get('GITHUB_REPOSITORY')
 
-        host = self.config['coveralls_host'].rstrip('/')
+        host = self.config.coveralls_host.rstrip('/')
         endpoint = f'{host}/webhook'
-        verify = not self.config['skip_ssl_verify']
-        timeout = self._request_timeout()
+        verify = not self.config.skip_ssl_verify
+        timeout = self.config.request_timeout
         try:
             response = requests.post(
                 endpoint, json=payload, verify=verify, timeout=timeout,
@@ -236,9 +224,7 @@ class Coveralls:
             return self._data
 
         self._data = {'source_files': self.get_coverage()} | git_info()
-        self._data.update({
-            k: self.config[k] for k in PAYLOAD_FIELDS if k in self.config
-        })
+        self._data.update(self.config.to_payload())
         if extra:
             if 'source_files' in extra:
                 self._data['source_files'].extend(extra['source_files'])
@@ -251,14 +237,13 @@ class Coveralls:
         return self._data
 
     def get_coverage(self):
-        config_file = self.config.get('config_file', True)
-        work = coverage.coverage(config_file=config_file)
+        work = coverage.coverage(config_file=self.config.config_file)
         work.load()
         work.get_data()
 
-        base_dir = self.config.get('base_dir') or ''
-        src_dir = self.config.get('src_dir') or ''
-        return CoverallReporter(work, base_dir, src_dir).coverage
+        return CoverallReporter(
+            work, self.config.base_dir, self.config.src_dir,
+        ).coverage
 
     @staticmethod
     def debug_bad_encoding(data):

--- a/coveralls/configuration.py
+++ b/coveralls/configuration.py
@@ -1,7 +1,9 @@
+import dataclasses
 import logging
 import os
 import pathlib
 import re
+from collections.abc import Mapping
 from typing import Any
 
 from .exception import CoverallsException
@@ -27,14 +29,9 @@ TOKENLESS_CI_SERVICES = frozenset({'travis-ci'})
 DEFAULT_CONNECT_TIMEOUT = 10
 DEFAULT_READ_TIMEOUT = 60
 
-TIMEOUT_FIELDS = ('timeout', 'connect_timeout', 'read_timeout')
-
-# The config keys that belong in the JSON submitted to coveralls.io -- every
-# job parameter the API accepts and lets the caller set. Everything else in the
-# config (base_dir, src_dir, config_file, the timeout family, ...) controls
-# local client behaviour and must never be sent: the uploaded payload already
-# includes every source file, so leaking client-only settings is both noise and
-# a needless disclosure.
+# Fields sent to the coveralls.io API -- every job parameter the /jobs endpoint
+# accepts and lets the caller set. Everything else on Config controls local
+# client behaviour and must never enter the submitted payload.
 # See https://docs.coveralls.io/api-jobs-endpoint (service_build_url and
 # service_branch are not in that table but are populated from CI and accepted;
 # git and source_files are computed elsewhere, not sourced from config).
@@ -51,6 +48,110 @@ PAYLOAD_FIELDS = (
     'parallel',
     'run_at',
 )
+
+
+@dataclasses.dataclass
+class Config:
+    # pylint: disable=too-many-instance-attributes
+    """
+    Fully resolved coveralls-python configuration.
+
+    Fields fall into two groups. The :data:`PAYLOAD_FIELDS` are sent to the
+    coveralls.io API via :meth:`to_payload`; every other field controls local
+    client behaviour (where to send, how to talk to coverage.py, etc.) and is
+    deliberately never included in the submitted payload.
+    """
+
+    # payload fields
+    repo_token: str | None = None
+    service_name: str = DEFAULT_SERVICE_NAME
+    service_number: str | None = None
+    service_job_id: str | None = None
+    service_job_number: str | None = None
+    service_pull_request: str | None = None
+    service_branch: str | None = None
+    service_build_url: str | None = None
+    flag_name: str | None = None
+    # None means "unset"; an explicit True/False is forwarded to the API so a
+    # caller can positively mark a job as non-parallel.
+    parallel: bool | None = None
+    # No CI/env loader populates run_at; it is a caller-only field, set via the
+    # config file or a Coveralls() kwarg, and forwarded because the API accepts
+    # it (a job timestamp, per the /jobs endpoint).
+    run_at: str | None = None
+
+    # client settings
+    coveralls_host: str = DEFAULT_HOST
+    skip_ssl_verify: bool = False
+    token_required: bool = True
+    base_dir: str = ''
+    src_dir: str = ''
+    # True lets coverage.py auto-discover its config file; a str names one.
+    config_file: str | bool = True
+    timeout: float | None = None
+    connect_timeout: float | None = None
+    read_timeout: float | None = None
+
+    def __post_init__(self) -> None:
+        self.timeout = self._validate_timeout('timeout', self.timeout)
+        self.connect_timeout = self._validate_timeout(
+            'connect_timeout', self.connect_timeout,
+        )
+        self.read_timeout = self._validate_timeout(
+            'read_timeout', self.read_timeout,
+        )
+
+    @staticmethod
+    def _validate_timeout(name: str, raw: Any) -> float | None:
+        if raw is None:
+            return None
+        try:
+            value = float(raw)
+        except (TypeError, ValueError) as e:
+            raise CoverallsException(
+                f'Invalid {name} value {raw!r}: must be a number.',
+            ) from e
+        if value <= 0:
+            raise CoverallsException(
+                f'Invalid {name} value {raw!r}: must be greater than 0.',
+            )
+        return value
+
+    @property
+    def request_timeout(self) -> tuple[float, float]:
+        """
+        Resolve the (connect, read) tuple passed to ``requests``.
+
+        A phase-specific value wins for its phase; otherwise the overall
+        ``timeout`` applies; otherwise the phase default is used.
+        """
+        connect = self.connect_timeout
+        if connect is None:
+            connect = self.timeout
+        if connect is None:
+            connect = DEFAULT_CONNECT_TIMEOUT
+
+        read = self.read_timeout
+        if read is None:
+            read = self.timeout
+        if read is None:
+            read = DEFAULT_READ_TIMEOUT
+
+        return (connect, read)
+
+    def to_payload(self) -> dict[str, Any]:
+        """Build the subset of config that is submitted to the API."""
+        # Include a field when it is set to anything other than None: an
+        # explicitly-falsey value (parallel=False, a numeric 0 job id) is a
+        # real choice and must be forwarded; only unset fields are dropped.
+        return {
+            name: value
+            for name in PAYLOAD_FIELDS
+            if (value := getattr(self, name)) is not None
+        }
+
+
+_FIELD_NAMES = frozenset(f.name for f in dataclasses.fields(Config))
 
 
 def _parse_pr_number(value: str | None) -> str | None:
@@ -213,6 +314,18 @@ def _from_environment() -> dict[str, Any]:
     return config
 
 
+def _filter_known(data: Mapping[str, Any], *, source: str) -> dict[str, Any]:
+    known = {}
+    for key, value in data.items():
+        if key in _FIELD_NAMES:
+            known[key] = value
+        else:
+            log.warning(
+                'Ignoring unknown config option %r from %s.', key, source,
+            )
+    return known
+
+
 def _from_file(config_filename: str) -> dict[str, Any]:
     try:
         import yaml  # pylint: disable=import-outside-toplevel
@@ -229,33 +342,18 @@ def _from_file(config_filename: str) -> dict[str, Any]:
         return {}
 
     # yaml.safe_load() returns None for an empty or comment-only file.
-    return yaml.safe_load(content) or {}
-
-
-def _validate_timeout(name: str, raw: Any) -> float | None:
-    if raw is None:
-        return None
-    try:
-        value = float(raw)
-    except (TypeError, ValueError) as e:
-        raise CoverallsException(
-            f'Invalid {name} value {raw!r}: must be a number.',
-        ) from e
-    if value <= 0:
-        raise CoverallsException(
-            f'Invalid {name} value {raw!r}: must be greater than 0.',
-        )
-    return value
+    data = yaml.safe_load(content) or {}
+    return _filter_known(data, source=config_filename)
 
 
 def resolve(
     config_filename: str,
-    overrides: dict[str, Any],
+    overrides: Mapping[str, Any],
     *,
     token_required: bool = True,
-) -> dict[str, Any]:
+) -> Config:
     """
-    Resolve configuration from every source into a single merged config.
+    Resolve configuration from all sources into a single typed Config.
 
     Precedence (later wins): CI environment, ``COVERALLS_*`` env vars, the
     config file, then explicit overrides (e.g. CLI flags).
@@ -267,9 +365,13 @@ def resolve(
     that authenticates uploads itself. A ``token_required`` key in the config
     file or environment is therefore ignored.
     """
-    cleaned = {
-        key: value for key, value in overrides.items() if value is not None
-    }
+    cleaned = _filter_known(
+        {
+            key: value for key, value in overrides.items()
+            if value is not None
+        },
+        source='arguments',
+    )
     name, fields = _detect_ci()
 
     partials = [
@@ -282,19 +384,14 @@ def resolve(
     merged: dict[str, Any] = {}
     for part in partials:
         merged.update(part)
-
     merged['token_required'] = (
         token_required and name not in TOKENLESS_CI_SERVICES
     )
-    merged.setdefault('service_name', DEFAULT_SERVICE_NAME)
-    merged.setdefault('coveralls_host', DEFAULT_HOST)
-    # parallel is a payload field: normalize it only when a source set it, so
-    # an unset value is omitted while an explicit parallel: false is forwarded.
-    if 'parallel' in merged:
-        merged['parallel'] = bool(merged['parallel'])
-    merged['skip_ssl_verify'] = bool(merged.get('skip_ssl_verify'))
-    for name in TIMEOUT_FIELDS:
-        if name in merged:
-            merged[name] = _validate_timeout(name, merged[name])
+    # Coerce the boolean flags: a config file may carry a non-bool (e.g. a
+    # quoted ``parallel: "yes"``), which must not reach the API or a client
+    # toggle as a stray string.
+    for flag in ('parallel', 'skip_ssl_verify'):
+        if flag in merged:
+            merged[flag] = bool(merged[flag])
 
-    return merged
+    return Config(**merged)

--- a/tests/api/config_test.py
+++ b/tests/api/config_test.py
@@ -1,0 +1,136 @@
+import dataclasses
+
+import pytest
+
+from coveralls.configuration import Config
+from coveralls.configuration import DEFAULT_CONNECT_TIMEOUT
+from coveralls.configuration import DEFAULT_HOST
+from coveralls.configuration import DEFAULT_READ_TIMEOUT
+from coveralls.configuration import PAYLOAD_FIELDS
+from coveralls.exception import CoverallsException
+
+
+def test_defaults():
+    config = Config()
+    assert config.repo_token is None
+    assert config.service_name == 'coveralls-python'
+    assert config.parallel is None
+    assert config.run_at is None
+    assert config.coveralls_host == DEFAULT_HOST
+    assert config.skip_ssl_verify is False
+    assert config.token_required is True
+    assert config.base_dir == ''
+    assert config.src_dir == ''
+    assert config.config_file is True
+    assert config.timeout is None
+    assert config.connect_timeout is None
+    assert config.read_timeout is None
+
+
+def test_to_payload_includes_only_set_payload_fields():
+    config = Config(repo_token='xxx', service_name='travis-ci', parallel=True)
+    assert config.to_payload() == {
+        'repo_token': 'xxx',
+        'service_name': 'travis-ci',
+        'parallel': True,
+    }
+
+
+def test_to_payload_omits_unset_payload_fields():
+    payload = Config(repo_token='xxx').to_payload()
+    # service_name always defaults to a real value; everything else is unset
+    assert payload == {'repo_token': 'xxx', 'service_name': 'coveralls-python'}
+    # parallel is unset (None) here, so it is not advertised at all
+    assert 'parallel' not in payload
+
+
+def test_to_payload_forwards_explicitly_set_falsey_fields():
+    # A caller who sets a payload field to a falsey value made an explicit
+    # choice; it must be forwarded rather than dropped like an unset field.
+    # parallel=False (an explicit --no-parallel) is the realistic falsey case.
+    payload = Config(repo_token='xxx', parallel=False).to_payload()
+    assert payload['parallel'] is False
+
+
+# Keep in sync with Config: every field is either a PAYLOAD_FIELDS entry or
+# listed here. test_payload_and_client_fields_..._cover_the_dataclass enforces
+# this, so add new fields to one list or the other.
+CLIENT_ONLY_FIELDS = (
+    'coveralls_host',
+    'skip_ssl_verify',
+    'token_required',
+    'base_dir',
+    'src_dir',
+    'config_file',
+    'timeout',
+    'connect_timeout',
+    'read_timeout',
+)
+
+
+def test_client_settings_never_leak_into_payload():
+    # Regression guard: base_dir/src_dir/config_file and the timeout family
+    # have all historically leaked into the submitted JSON via a config bag.
+    payload = Config(
+        repo_token='xxx',
+        coveralls_host='https://enterprise.example.com',
+        skip_ssl_verify=True,
+        base_dir='b',
+        src_dir='s',
+        config_file='.coveragerc',
+        timeout=30,
+        connect_timeout=5,
+        read_timeout=25,
+    ).to_payload()
+    for name in CLIENT_ONLY_FIELDS:
+        assert name not in payload
+
+
+def test_payload_and_client_fields_are_disjoint_and_cover_the_dataclass():
+    field_names = {f.name for f in dataclasses.fields(Config)}
+    assert set(PAYLOAD_FIELDS).isdisjoint(CLIENT_ONLY_FIELDS)
+    assert set(PAYLOAD_FIELDS) | set(CLIENT_ONLY_FIELDS) == field_names
+
+
+TIMEOUT_FIELDS = ['timeout', 'connect_timeout', 'read_timeout']
+
+
+@pytest.mark.parametrize('name', TIMEOUT_FIELDS)
+def test_timeout_accepts_numeric_strings(name):
+    config = Config(**{name: '15'})
+    assert getattr(config, name) == 15.0
+
+
+@pytest.mark.parametrize('name', TIMEOUT_FIELDS)
+def test_timeout_rejects_non_numeric(name):
+    with pytest.raises(CoverallsException, match='must be a number'):
+        Config(**{name: 'abc'})
+
+
+@pytest.mark.parametrize('name', TIMEOUT_FIELDS)
+@pytest.mark.parametrize('value', [0, -1])
+def test_timeout_rejects_non_positive(name, value):
+    with pytest.raises(CoverallsException, match='greater than 0'):
+        Config(**{name: value})
+
+
+def test_request_timeout_defaults():
+    assert Config().request_timeout == (
+        DEFAULT_CONNECT_TIMEOUT, DEFAULT_READ_TIMEOUT,
+    )
+
+
+def test_request_timeout_overall_applies_to_both_phases():
+    assert Config(timeout=30).request_timeout == (30.0, 30.0)
+
+
+def test_request_timeout_phase_specific_wins_over_overall():
+    config = Config(timeout=30, connect_timeout=5, read_timeout=45)
+    assert config.request_timeout == (5.0, 45.0)
+
+
+def test_request_timeout_phase_specific_falls_back_to_default():
+    # only connect overridden -> read falls back to its default
+    assert Config(connect_timeout=5).request_timeout == (
+        5.0, DEFAULT_READ_TIMEOUT,
+    )

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -1,6 +1,4 @@
 import os
-import pathlib
-import tempfile
 import unittest.mock
 
 import pytest
@@ -10,68 +8,94 @@ except ImportError:
     yaml = None  # type: ignore[assignment]
 
 from coveralls import Coveralls
-from coveralls.api import log
+from coveralls.exception import CoverallsException
 
 
+# The per-source resolution rules (CI detection, env vars, file loading,
+# precedence) are covered in resolve_test.py and config_test.py. These tests
+# assert the Coveralls entrypoint consumes a resolved, typed Config correctly.
 @unittest.mock.patch.object(Coveralls, 'config_filename', '.coveralls.mock')
-class Configuration(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.old_cwd = pathlib.Path.cwd()
-
-    @classmethod
-    def tearDownClass(cls):
-        os.chdir(cls.old_cwd)
-
-    def setUp(self):
-        self.dir = tempfile.mkdtemp()
-        os.chdir(self.dir)
-        with open('.coveralls.mock', 'w+') as fp:
-            fp.write('repo_token: xxx\n')
-            fp.write('service_name: jenkins\n')
-
+class TestConfigIntegration:
     @pytest.mark.skipif(yaml is None, reason='requires PyYAML')
     @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_local_with_config(self):
-        cover = Coveralls()
-        assert cover.config['service_name'] == 'jenkins'
-        assert cover.config['repo_token'] == 'xxx'
-        assert 'service_job_id' not in cover.config
+    def test_reads_config_file(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / '.coveralls.mock').write_text(
+            'repo_token: xxx\nservice_name: jenkins\n',
+        )
 
-    @pytest.mark.skipif(yaml is not None, reason='requires no PyYAML')
+        cover = Coveralls()
+
+        assert cover.config.service_name == 'jenkins'
+        assert cover.config.repo_token == 'xxx'
+        assert cover.config.service_job_id is None
+
     @unittest.mock.patch.dict(
         os.environ,
-        {'COVERALLS_REPO_TOKEN': 'xxx'},
+        {
+            'COVERALLS_HOST': 'https://enterprise.example.com',
+            'COVERALLS_PARALLEL': 'true',
+            'COVERALLS_REPO_TOKEN': 'a1b2c3d4',
+            'COVERALLS_SERVICE_NAME': 'bbb',
+        },
         clear=True,
     )
-    def test_local_with_config_without_yaml_module(self):
-        """test local with config in yaml, but without yaml-installed"""
-        with unittest.mock.patch.object(log, 'warning') as logger:
-            cover = Coveralls()
+    def test_reads_environment(self):
+        cover = Coveralls()
 
-        logger.assert_called_once_with(
-            'PyYAML is not installed, skipping %s.', cover.config_filename,
+        assert cover.config.coveralls_host == 'https://enterprise.example.com'
+        assert cover.config.parallel is True
+        assert cover.config.repo_token == 'a1b2c3d4'
+        assert cover.config.service_name == 'bbb'
+
+    @unittest.mock.patch.dict(os.environ, {}, clear=True)
+    def test_overrides_win(self):
+        cover = Coveralls(
+            repo_token='yyy',
+            service_name='coveralls-aaa',
+            coveralls_host='https://coveralls.aaa.com',
         )
+
+        assert cover.config.repo_token == 'yyy'
+        assert cover.config.service_name == 'coveralls-aaa'
+        assert cover.config.coveralls_host == 'https://coveralls.aaa.com'
+
+    @unittest.mock.patch.dict(
+        os.environ,
+        {'COVERALLS_REPO_TOKEN': 'xxx', 'COVERALLS_TIMEOUT': 'abc'},
+        clear=True,
+    )
+    def test_invalid_timeout_raises_on_construction(self):
+        with pytest.raises(CoverallsException, match='must be a number'):
+            Coveralls()
 
 
 @unittest.mock.patch.object(Coveralls, 'config_filename', '.coveralls.mock')
-class NoConfiguration(unittest.TestCase):
+class TestEnsureToken:
     @unittest.mock.patch.dict(
-        os.environ, {
+        os.environ,
+        {
             'TRAVIS': 'True',
             'TRAVIS_JOB_ID': '777',
             'COVERALLS_REPO_TOKEN': 'yyy',
-        }, clear=True,
+        },
+        clear=True,
     )
     def test_repo_token_from_env(self):
         cover = Coveralls()
-        assert cover.config['service_name'] == 'travis-ci'
-        assert cover.config['service_job_id'] == '777'
-        assert cover.config['repo_token'] == 'yyy'
+        assert cover.config.service_name == 'travis-ci'
+        assert cover.config.service_job_id == '777'
+        assert cover.config.repo_token == 'yyy'
+
+    @unittest.mock.patch.dict(os.environ, {'TRAVIS': 'True'}, clear=True)
+    def test_travis_needs_no_token(self):
+        cover = Coveralls()
+        assert cover.config.token_required is False
+        assert cover.config.repo_token is None
 
     @unittest.mock.patch.dict(os.environ, {}, clear=True)
     def test_misconfigured(self):
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(CoverallsException) as excinfo:
             Coveralls()
 
         assert str(excinfo.value) == (
@@ -85,413 +109,9 @@ class NoConfiguration(unittest.TestCase):
         clear=True,
     )
     def test_misconfigured_github(self):
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(CoverallsException) as excinfo:
             Coveralls()
 
         assert str(excinfo.value).startswith(
             'Running on Github Actions but GITHUB_TOKEN is not set.',
         )
-
-    @unittest.mock.patch.dict(
-        os.environ, {
-            'APPVEYOR': 'True',
-            'APPVEYOR_BUILD_ID': '1234567',
-            'APPVEYOR_PULL_REQUEST_NUMBER': '1234',
-        },
-        clear=True,
-    )
-    def test_appveyor_no_config(self):
-        cover = Coveralls(repo_token='xxx')
-        assert cover.config['service_name'] == 'appveyor'
-        assert cover.config['service_job_id'] == '1234567'
-        assert cover.config['service_pull_request'] == '1234'
-
-    @unittest.mock.patch.dict(
-        os.environ, {
-            'BUILDKITE': 'True',
-            'BUILDKITE_JOB_ID': '1234567',
-            'BUILDKITE_PULL_REQUEST': '1234',
-        },
-        clear=True,
-    )
-    def test_buildkite_no_config(self):
-        cover = Coveralls(repo_token='xxx')
-        assert cover.config['service_name'] == 'buildkite'
-        assert cover.config['service_job_id'] == '1234567'
-        assert cover.config['service_pull_request'] == '1234'
-
-    @unittest.mock.patch.dict(
-        os.environ, {
-            'BUILDKITE': 'True',
-            'BUILDKITE_JOB_ID': '1234567',
-            'BUILDKITE_PULL_REQUEST': 'false',
-        },
-        clear=True,
-    )
-    def test_buildkite_no_config_no_pr(self):
-        cover = Coveralls(repo_token='xxx')
-        assert cover.config['service_name'] == 'buildkite'
-        assert cover.config['service_job_id'] == '1234567'
-        assert 'service_pull_request' not in cover.config
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'CIRCLECI': 'True',
-            'CIRCLE_BUILD_NUM': '888',
-            'CI_PULL_REQUEST': 'https://github.com/org/repo/pull/9999',
-        },
-        clear=True,
-    )
-    def test_circleci_singular_no_config(self):
-        cover = Coveralls(repo_token='xxx')
-        assert cover.config['service_name'] == 'circleci'
-        assert cover.config['service_number'] == '888'
-        assert cover.config['service_pull_request'] == '9999'
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'CIRCLECI': 'True',
-            'CIRCLE_WORKFLOW_ID': '0ea2c0f7-4e56-4a94-bf77-bfae6bdbf80a',
-            'CIRCLE_NODE_INDEX': '15',
-        },
-        clear=True,
-    )
-    def test_circleci_parallel_no_config(self):
-        cover = Coveralls(repo_token='xxx')
-        assert cover.config['service_name'] == 'circleci'
-        assert cover.config['service_number'] == (
-            '0ea2c0f7-4e56-4a94-bf77-bfae6bdbf80a'
-        )
-        assert cover.config['service_job_id'] == '15'
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'GITHUB_ACTIONS': 'true',
-            'GITHUB_REF': 'refs/pull/1234/merge',
-            'GITHUB_SHA': 'bb0e00166b28f49db04d6a8b8cb4bddb5afa529f',
-            'GITHUB_RUN_ID': '123456789',
-            'GITHUB_RUN_NUMBER': '12',
-            'GITHUB_HEAD_REF': 'fixup-branch',
-            'COVERALLS_REPO_TOKEN': 'xxx',
-        },
-        clear=True,
-    )
-    def test_github_no_config(self):
-        cover = Coveralls()
-        assert cover.config['service_name'] == 'github'
-        assert cover.config['service_pull_request'] == '1234'
-        assert cover.config['service_number'] == '123456789'
-        assert cover.config['service_job_id'] == '123456789'
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'GITHUB_ACTIONS': 'true',
-            'GITHUB_TOKEN': 'xxx',
-            'GITHUB_REF': 'refs/heads/master',
-            'GITHUB_SHA': 'bb0e00166b28f49db04d6a8b8cb4bddb5afa529f',
-            'GITHUB_RUN_ID': '987654321',
-            'GITHUB_RUN_NUMBER': '21',
-            'GITHUB_HEAD_REF': '',
-        },
-        clear=True,
-    )
-    def test_github_no_config_no_pr(self):
-        cover = Coveralls()
-        assert cover.config['service_name'] == 'github'
-        assert cover.config['service_number'] == '987654321'
-        assert cover.config['service_job_id'] == '987654321'
-        assert 'service_pull_request' not in cover.config
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'JENKINS_HOME': '/var/lib/jenkins',
-            'BUILD_NUMBER': '888',
-            'CI_PULL_REQUEST': 'https://github.com/org/repo/pull/9999',
-        },
-        clear=True,
-    )
-    def test_jenkins_no_config(self):
-        cover = Coveralls(repo_token='xxx')
-        assert cover.config['service_name'] == 'jenkins'
-        assert cover.config['service_job_id'] == '888'
-        assert cover.config['service_pull_request'] == '9999'
-
-    @unittest.mock.patch.dict(
-        os.environ, {
-            'TRAVIS': 'True',
-            'TRAVIS_JOB_ID': '777',
-        }, clear=True,
-    )
-    def test_travis_no_config(self):
-        cover = Coveralls()
-        assert cover.config['service_name'] == 'travis-ci'
-        assert cover.config['service_job_id'] == '777'
-        assert 'repo_token' not in cover.config
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'TRAVIS': 'True', 'TRAVIS_JOB_ID': '777',
-            'TRAVIS_PULL_REQUEST': 'false',
-        },
-        clear=True,
-    )
-    def test_travis_no_pr_false_sentinel(self):
-        # Travis sets TRAVIS_PULL_REQUEST='false' on non-PR builds; the 'false'
-        # sentinel must not leak into the payload as a PR number.
-        cover = Coveralls(repo_token='xxx')
-        assert 'service_pull_request' not in cover.config
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'SEMAPHORE': 'True',
-            'SEMAPHORE_EXECUTABLE_UUID': '36980c73',
-            'SEMAPHORE_JOB_UUID': 'a26d42cf',
-            'SEMAPHORE_BRANCH_ID': '9999',
-        },
-        clear=True,
-    )
-    def test_semaphore_classic_no_config(self):
-        cover = Coveralls(repo_token='xxx')
-        assert cover.config['service_name'] == 'semaphore-ci'
-        assert cover.config['service_job_id'] == 'a26d42cf'
-        assert cover.config['service_number'] == '36980c73'
-        assert cover.config['service_pull_request'] == '9999'
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'SEMAPHORE': 'True',
-            'SEMAPHORE_WORKFLOW_ID': 'b86b3adf',
-            'SEMAPHORE_JOB_ID': '2b942b49',
-            'SEMAPHORE_GIT_PR_NUMBER': '9999',
-        },
-        clear=True,
-    )
-    def test_semaphore_20_no_config(self):
-        cover = Coveralls(repo_token='xxx')
-        assert cover.config['service_name'] == 'semaphore-ci'
-        assert cover.config['service_job_id'] == '2b942b49'
-        assert cover.config['service_number'] == 'b86b3adf'
-        assert cover.config['service_pull_request'] == '9999'
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'CI_NAME': 'generic-ci',
-            'CI_PULL_REQUEST': 'pull/1234',
-            'CI_JOB_ID': 'bb0e00166',
-            'CI_BUILD_NUMBER': '3',
-            'CI_BUILD_URL': 'https://generic-ci.local/build/123456789',
-            'CI_BRANCH': 'fixup-branch',
-            'COVERALLS_REPO_TOKEN': 'xxx',
-        },
-        clear=True,
-    )
-    def test_generic_no_config(self):
-        cover = Coveralls()
-        assert cover.config['service_name'] == 'generic-ci'
-        assert cover.config['service_job_id'] == 'bb0e00166'
-        assert cover.config['service_branch'] == 'fixup-branch'
-        assert cover.config['service_pull_request'] == '1234'
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'CI_NAME': 'generic-ci',
-            'CI_PULL_REQUEST': '',
-            'CI_JOB_ID': 'bb0e00166',
-            'CI_BUILD_NUMBER': '3',
-            'CI_BUILD_URL': 'https://generic-ci.local/build/123456789',
-            'CI_BRANCH': 'fixup-branch',
-            'COVERALLS_REPO_TOKEN': 'xxx',
-        },
-        clear=True,
-    )
-    def test_generic_no_config_no_pr(self):
-        cover = Coveralls()
-        assert cover.config['service_name'] == 'generic-ci'
-        assert cover.config['service_job_id'] == 'bb0e00166'
-        assert cover.config['service_branch'] == 'fixup-branch'
-        assert 'service_pull_request' not in cover.config
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'COVERALLS_HOST': 'aaa',
-            'COVERALLS_PARALLEL': 'true',
-            'COVERALLS_REPO_TOKEN': 'a1b2c3d4',
-            'COVERALLS_SERVICE_NAME': 'bbb',
-            'COVERALLS_FLAG_NAME': 'cc',
-            'COVERALLS_SERVICE_JOB_NUMBER': '1234',
-        },
-        clear=True,
-    )
-    def test_service_name_from_env(self):
-        cover = Coveralls()
-        assert cover.config['coveralls_host'] == 'aaa'
-        assert cover.config['parallel'] is True
-        assert cover.config['repo_token'] == 'a1b2c3d4'
-        assert cover.config['service_name'] == 'bbb'
-        assert cover.config['flag_name'] == 'cc'
-        assert cover.config['service_job_number'] == '1234'
-
-
-@unittest.mock.patch.object(Coveralls, 'config_filename', '.coveralls.mock')
-class CLIConfiguration(unittest.TestCase):
-    def test_load_config(self):
-        cover = Coveralls(
-            repo_token='yyy',
-            service_name='coveralls-aaa',
-            coveralls_host='https://coveralls.aaa.com',
-        )
-        assert cover.config['repo_token'] == 'yyy'
-        assert cover.config['service_name'] == 'coveralls-aaa'
-        assert cover.config['coveralls_host'] == 'https://coveralls.aaa.com'
-
-
-@unittest.mock.patch.object(Coveralls, 'config_filename', '.coveralls.mock')
-class TimeoutConfiguration(unittest.TestCase):
-    @classmethod
-    def setUpClass(cls):
-        cls.old_cwd = pathlib.Path.cwd()
-
-    @classmethod
-    def tearDownClass(cls):
-        os.chdir(cls.old_cwd)
-
-    @pytest.mark.skipif(yaml is None, reason='requires PyYAML')
-    @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_timeout_from_file(self):
-        # pylint: disable=protected-access
-        os.chdir(tempfile.mkdtemp())
-        with open('.coveralls.mock', 'w+') as fp:
-            fp.write('repo_token: xxx\n')
-            fp.write('timeout: 45\n')
-        cover = Coveralls()
-        assert cover.config['timeout'] == 45.0
-        assert cover._request_timeout() == (45.0, 45.0)
-
-    @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_default_timeout(self):
-        # pylint: disable=protected-access
-        cover = Coveralls(repo_token='xxx')
-        assert cover._request_timeout() == (10, 60)
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {'COVERALLS_REPO_TOKEN': 'xxx', 'COVERALLS_TIMEOUT': '30'},
-        clear=True,
-    )
-    def test_overall_timeout_from_env(self):
-        # pylint: disable=protected-access
-        cover = Coveralls()
-        assert cover.config['timeout'] == 30.0
-        assert cover._request_timeout() == (30.0, 30.0)
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'COVERALLS_REPO_TOKEN': 'xxx',
-            'COVERALLS_CONNECT_TIMEOUT': '5',
-            'COVERALLS_READ_TIMEOUT': '90',
-        },
-        clear=True,
-    )
-    def test_phase_timeouts_from_env(self):
-        # pylint: disable=protected-access
-        cover = Coveralls()
-        assert cover._request_timeout() == (5.0, 90.0)
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'COVERALLS_REPO_TOKEN': 'xxx',
-            'COVERALLS_TIMEOUT': '30',
-            'COVERALLS_CONNECT_TIMEOUT': '5',
-        },
-        clear=True,
-    )
-    def test_phase_timeout_overrides_overall(self):
-        # pylint: disable=protected-access
-        cover = Coveralls()
-        assert cover._request_timeout() == (5.0, 30.0)
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {'COVERALLS_REPO_TOKEN': 'xxx', 'COVERALLS_TIMEOUT': 'abc'},
-        clear=True,
-    )
-    def test_invalid_timeout_raises(self):
-        with pytest.raises(Exception) as excinfo:
-            Coveralls()
-        assert 'Invalid timeout' in str(excinfo.value)
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {'COVERALLS_REPO_TOKEN': 'xxx', 'COVERALLS_READ_TIMEOUT': '0'},
-        clear=True,
-    )
-    def test_non_positive_timeout_raises(self):
-        with pytest.raises(Exception) as excinfo:
-            Coveralls()
-        assert 'greater than 0' in str(excinfo.value)
-
-
-@unittest.mock.patch.object(Coveralls, 'config_filename', '.coveralls.mock')
-class TokenRequired(unittest.TestCase):
-    """token_required guards against accidental tokenless uploads.
-
-    Only CI detection and the explicit constructor argument may waive it; the
-    config file and env vars must not, so a committed .coveralls.yml cannot
-    silently disable the check.
-    """
-
-    def setUp(self):
-        self._old_cwd = pathlib.Path.cwd()
-
-    def tearDown(self):
-        # Restore cwd per-test: test_config_file_cannot_waive chdir's into a
-        # temp dir, and leaking that would break cwd-sensitive tests (e.g.
-        # git_test) that run afterwards.
-        os.chdir(self._old_cwd)
-
-    @unittest.mock.patch.dict(
-        os.environ, {'TRAVIS': 'True', 'TRAVIS_JOB_ID': '777'}, clear=True,
-    )
-    def test_ci_waives(self):
-        cover = Coveralls()
-        assert cover.config['token_required'] is False
-
-    @unittest.mock.patch.dict(
-        os.environ, {'APPVEYOR': 'True', 'APPVEYOR_BUILD_ID': '1'}, clear=True,
-    )
-    def test_non_tokenless_ci_still_requires_token(self):
-        # Only services that authenticate uploads themselves waive the token;
-        # a normal CI service must still provide one.
-        with pytest.raises(Exception) as excinfo:
-            Coveralls()
-        assert 'provide either repo_token' in str(excinfo.value)
-
-    @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_constructor_argument_waives(self):
-        cover = Coveralls(token_required=False)
-        assert cover.config['token_required'] is False
-
-    @pytest.mark.skipif(yaml is None, reason='requires PyYAML')
-    @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_config_file_cannot_waive(self):
-        # A token_required: false in the config file is ignored: it is not a
-        # user-facing setting and must not disable the guard.
-        os.chdir(tempfile.mkdtemp())
-        pathlib.Path('.coveralls.mock').write_text('token_required: false\n')
-
-        with pytest.raises(Exception) as excinfo:
-            Coveralls()
-        assert 'provide either repo_token' in str(excinfo.value)

--- a/tests/api/resolve_test.py
+++ b/tests/api/resolve_test.py
@@ -1,0 +1,427 @@
+import os
+import unittest.mock
+
+import pytest
+try:
+    import yaml
+except ImportError:
+    yaml = None  # type: ignore[assignment]
+
+from coveralls.configuration import Config
+from coveralls.configuration import log
+from coveralls.configuration import resolve
+from coveralls.configuration import _parse_pr_number
+
+
+def resolve_config(*, token_required=True, **overrides):
+    return resolve(
+        '.coveralls.mock', overrides, token_required=token_required,
+    )
+
+
+@pytest.mark.parametrize(
+    ('value', 'expected'),
+    [
+        ('42', '42'),
+        ('pull/42', '42'),
+        ('https://github.com/org/repo/pull/42', '42'),
+        ('', None),
+        (None, None),
+        ('pull/42/', None),
+    ],
+)
+def test_parse_pr_number(value, expected):
+    # All CI loaders share this one trailing-integer semantic.
+    assert _parse_pr_number(value) == expected
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_no_environment_defaults():
+    config = resolve_config()
+    assert config.service_name == 'coveralls-python'
+    assert config.repo_token is None
+    assert config.token_required is True
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {'TRAVIS': 'True', 'TRAVIS_JOB_ID': '777'},
+    clear=True,
+)
+def test_travis_waives_token_requirement():
+    config = resolve_config()
+    assert config.service_name == 'travis-ci'
+    assert config.service_job_id == '777'
+    assert config.token_required is False
+    assert config.repo_token is None
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {'TRAVIS': 'True', 'TRAVIS_JOB_ID': '777', 'TRAVIS_PULL_REQUEST': 'false'},
+    clear=True,
+)
+def test_travis_no_pr_false_sentinel():
+    # Travis sets TRAVIS_PULL_REQUEST='false' on non-PR builds; the shared
+    # trailing-integer parser drops the sentinel like it does for Buildkite.
+    config = resolve_config(repo_token='xxx')
+    assert config.service_name == 'travis-ci'
+    assert config.service_pull_request is None
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {
+        'APPVEYOR': 'True',
+        'APPVEYOR_BUILD_ID': '1234567',
+        'APPVEYOR_PULL_REQUEST_NUMBER': '1234',
+    },
+    clear=True,
+)
+def test_appveyor():
+    config = resolve_config(repo_token='xxx')
+    assert config.service_name == 'appveyor'
+    assert config.service_job_id == '1234567'
+    assert config.service_pull_request == '1234'
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {
+        'BUILDKITE': 'True',
+        'BUILDKITE_JOB_ID': '1234567',
+        'BUILDKITE_PULL_REQUEST': 'false',
+    },
+    clear=True,
+)
+def test_buildkite_no_pr():
+    config = resolve_config(repo_token='xxx')
+    assert config.service_name == 'buildkite'
+    assert config.service_job_id == '1234567'
+    assert config.service_pull_request is None
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {
+        'CIRCLECI': 'True',
+        'CIRCLE_BUILD_NUM': '888',
+        'CI_PULL_REQUEST': 'https://github.com/org/repo/pull/9999',
+    },
+    clear=True,
+)
+def test_circleci_singular():
+    config = resolve_config(repo_token='xxx')
+    assert config.service_name == 'circleci'
+    assert config.service_number == '888'
+    assert config.service_pull_request == '9999'
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {
+        'CIRCLECI': 'True',
+        'CIRCLE_WORKFLOW_ID': '0ea2c0f7-4e56-4a94-bf77-bfae6bdbf80a',
+        'CIRCLE_NODE_INDEX': '15',
+    },
+    clear=True,
+)
+def test_circleci_parallel():
+    config = resolve_config(repo_token='xxx')
+    assert config.service_name == 'circleci'
+    assert config.service_number == '0ea2c0f7-4e56-4a94-bf77-bfae6bdbf80a'
+    assert config.service_job_id == '15'
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {
+        'GITHUB_ACTIONS': 'true',
+        'GITHUB_REF': 'refs/pull/1234/merge',
+        'GITHUB_RUN_ID': '123456789',
+        'COVERALLS_REPO_TOKEN': 'xxx',
+    },
+    clear=True,
+)
+def test_github_repo_token_from_env():
+    config = resolve_config()
+    assert config.service_name == 'github'
+    assert config.service_pull_request == '1234'
+    assert config.service_number == '123456789'
+    assert config.service_job_id == '123456789'
+    assert config.repo_token == 'xxx'
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {
+        'GITHUB_ACTIONS': 'true',
+        'GITHUB_TOKEN': 'ght',
+        'GITHUB_REF': 'refs/heads/master',
+        'GITHUB_RUN_ID': '987654321',
+    },
+    clear=True,
+)
+def test_github_token_no_pr():
+    config = resolve_config()
+    assert config.service_name == 'github'
+    assert config.repo_token == 'ght'
+    assert config.service_pull_request is None
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {
+        'JENKINS_HOME': '/var/lib/jenkins',
+        'BUILD_NUMBER': '888',
+        'CI_PULL_REQUEST': 'https://github.com/org/repo/pull/9999',
+    },
+    clear=True,
+)
+def test_jenkins():
+    config = resolve_config(repo_token='xxx')
+    assert config.service_name == 'jenkins'
+    assert config.service_job_id == '888'
+    assert config.service_pull_request == '9999'
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {
+        'SEMAPHORE': 'True',
+        'SEMAPHORE_EXECUTABLE_UUID': '36980c73',
+        'SEMAPHORE_JOB_UUID': 'a26d42cf',
+        'SEMAPHORE_BRANCH_ID': '9999',
+    },
+    clear=True,
+)
+def test_semaphore_classic():
+    config = resolve_config(repo_token='xxx')
+    assert config.service_name == 'semaphore-ci'
+    assert config.service_job_id == 'a26d42cf'
+    assert config.service_number == '36980c73'
+    assert config.service_pull_request == '9999'
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {
+        'SEMAPHORE': 'True',
+        'SEMAPHORE_WORKFLOW_ID': 'b86b3adf',
+        'SEMAPHORE_JOB_ID': '2b942b49',
+        'SEMAPHORE_GIT_PR_NUMBER': '9999',
+    },
+    clear=True,
+)
+def test_semaphore_20():
+    config = resolve_config(repo_token='xxx')
+    assert config.service_name == 'semaphore-ci'
+    assert config.service_job_id == '2b942b49'
+    assert config.service_number == 'b86b3adf'
+    assert config.service_pull_request == '9999'
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {
+        'CI_NAME': 'generic-ci',
+        'CI_PULL_REQUEST': 'pull/1234',
+        'CI_JOB_ID': 'bb0e00166',
+        'CI_BUILD_NUMBER': '3',
+        'CI_BUILD_URL': 'https://generic-ci.local/build/123456789',
+        'CI_BRANCH': 'fixup-branch',
+        'COVERALLS_REPO_TOKEN': 'xxx',
+    },
+    clear=True,
+)
+def test_generic_ci():
+    config = resolve_config()
+    assert config.service_name == 'generic-ci'
+    assert config.service_job_id == 'bb0e00166'
+    assert config.service_branch == 'fixup-branch'
+    assert config.service_pull_request == '1234'
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {'CIRCLECI': 'True', 'CI_NAME': 'generic-ci', 'CIRCLE_BUILD_NUM': '888'},
+    clear=True,
+)
+def test_generic_ci_name_wins_over_specific_service():
+    config = resolve_config(repo_token='xxx')
+    assert config.service_name == 'generic-ci'
+    # ...but the specific service still contributes its number
+    assert config.service_number == '888'
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {
+        'COVERALLS_HOST': 'https://enterprise.example.com',
+        'COVERALLS_PARALLEL': 'true',
+        'COVERALLS_REPO_TOKEN': 'a1b2c3d4',
+        'COVERALLS_SERVICE_NAME': 'bbb',
+        'COVERALLS_FLAG_NAME': 'cc',
+        'COVERALLS_SERVICE_JOB_NUMBER': '1234',
+        'COVERALLS_SKIP_SSL_VERIFY': '1',
+        'COVERALLS_TIMEOUT': '30',
+    },
+    clear=True,
+)
+def test_environment_variables():
+    config = resolve_config()
+    assert config.coveralls_host == 'https://enterprise.example.com'
+    assert config.parallel is True
+    assert config.repo_token == 'a1b2c3d4'
+    assert config.service_name == 'bbb'
+    assert config.flag_name == 'cc'
+    assert config.service_job_number == '1234'
+    assert config.skip_ssl_verify is True
+    assert config.timeout == 30.0
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_overrides_win_over_environment():
+    with unittest.mock.patch.dict(os.environ, {'COVERALLS_HOST': 'env'}):
+        config = resolve_config(
+            coveralls_host='cli', service_name='cli-service',
+        )
+    assert config.coveralls_host == 'cli'
+    assert config.service_name == 'cli-service'
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_none_overrides_do_not_clobber():
+    env = {'COVERALLS_SERVICE_NAME': 'env'}
+    with unittest.mock.patch.dict(os.environ, env):
+        config = resolve_config(service_name=None)
+    assert config.service_name == 'env'
+
+
+@unittest.mock.patch.dict(
+    os.environ, {'TRAVIS': 'True'}, clear=True,
+)
+def test_override_cannot_reimpose_waived_token():
+    # debug/output pass token_required implicitly; travis waives it. Neither an
+    # explicit True override nor travis should be able to flip it back on.
+    config = resolve_config(token_required=True)
+    assert config.token_required is False
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_override_waives_token():
+    config = resolve_config(token_required=False)
+    assert config.token_required is False
+
+
+@pytest.mark.skipif(yaml is None, reason='requires PyYAML')
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_config_file_cannot_waive_token_required(tmp_path, monkeypatch):
+    # token_required is a security guard, not a user-facing setting: a
+    # token_required: false in the config file must be ignored so a committed
+    # .coveralls.yml cannot silently disable the check.
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / '.coveralls.mock').write_text('token_required: false\n')
+    config = resolve('.coveralls.mock', {})
+    assert config.token_required is True
+
+
+def test_bool_override_precedence_is_owned_by_resolve():
+    # A None override means "unset" and must not clobber env/file; an explicit
+    # False override wins. This is the single rule resolve() enforces for both
+    # CLI (--no-parallel) and library callers.
+    env = {'COVERALLS_PARALLEL': 'true', 'COVERALLS_SKIP_SSL_VERIFY': '1'}
+    with unittest.mock.patch.dict(os.environ, env, clear=True):
+        assert resolve_config(parallel=None).parallel is True
+        assert resolve_config(parallel=False).parallel is False
+        assert resolve_config(skip_ssl_verify=None).skip_ssl_verify is True
+        assert resolve_config(skip_ssl_verify=False).skip_ssl_verify is False
+
+
+@pytest.mark.skipif(yaml is None, reason='requires PyYAML')
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_file_source_and_unknown_key_warning(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / '.coveralls.mock').write_text(
+        'repo_token: xxx\nservice_name: jenkins\nbogus_key: nope\n',
+    )
+    with unittest.mock.patch.object(log, 'warning') as warning:
+        config = resolve('.coveralls.mock', {})
+
+    assert config.repo_token == 'xxx'
+    assert config.service_name == 'jenkins'
+    warning.assert_called_once_with(
+        'Ignoring unknown config option %r from %s.',
+        'bogus_key', '.coveralls.mock',
+    )
+
+
+@pytest.mark.skipif(yaml is None, reason='requires PyYAML')
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_bool_flags_are_coerced_from_config_file(tmp_path, monkeypatch):
+    # A config file may carry a non-bool (e.g. a quoted parallel: "yes"); it
+    # must be normalized rather than forwarded to the API as a stray string.
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / '.coveralls.mock').write_text(
+        'repo_token: xxx\nparallel: "yes"\nskip_ssl_verify: "1"\n',
+    )
+    config = resolve('.coveralls.mock', {})
+    assert config.parallel is True
+    assert config.skip_ssl_verify is True
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_unknown_override_key_warns_and_is_dropped():
+    # Same rule as the config file: an unknown key from any source is dropped
+    # with a warning rather than crashing (previously a raw TypeError from
+    # Config(**merged) for an unexpected Coveralls() kwarg).
+    with unittest.mock.patch.object(log, 'warning') as warning:
+        config = resolve_config(repo_token='xxx', bogus_key='nope')
+
+    assert config.repo_token == 'xxx'
+    assert not hasattr(config, 'bogus_key')
+    warning.assert_called_once_with(
+        'Ignoring unknown config option %r from %s.', 'bogus_key', 'arguments',
+    )
+
+
+@pytest.mark.skipif(yaml is not None, reason='requires no PyYAML')
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_file_source_without_yaml_warns():
+    with unittest.mock.patch.object(log, 'warning') as warning:
+        resolve('.coveralls.mock', {})
+    warning.assert_called_once_with(
+        'PyYAML is not installed, skipping %s.', '.coveralls.mock',
+    )
+
+
+def test_resolve_returns_config_instance():
+    assert isinstance(resolve_config(), Config)
+
+
+@pytest.mark.skipif(yaml is None, reason='requires PyYAML')
+@pytest.mark.parametrize('content', ['', '\n\n', '# only a comment\n'])
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_empty_config_file_is_ignored(content, tmp_path, monkeypatch):
+    # yaml.safe_load() returns None for empty/comment-only files; resolve must
+    # treat that as no config rather than crashing on a None update.
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / '.coveralls.mock').write_text(content)
+
+    config = resolve('.coveralls.mock', {})
+
+    assert config.service_name == 'coveralls-python'
+    assert config.repo_token is None
+
+
+@pytest.mark.skipif(yaml is None, reason='requires PyYAML')
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_none_config_file_override_keeps_file_value(tmp_path, monkeypatch):
+    # The CLI forwards config_file=None when unset; that must not override a
+    # config_file set in the config file.
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / '.coveralls.mock').write_text(
+        'repo_token: xxx\nconfig_file: from_yaml.rc\n',
+    )
+    config = resolve('.coveralls.mock', {'config_file': None})
+    assert config.config_file == 'from_yaml.rc'

--- a/tests/api/wear_test.py
+++ b/tests/api/wear_test.py
@@ -168,6 +168,20 @@ class WearTest(unittest.TestCase):
         )
 
     @unittest.mock.patch.dict(os.environ, {}, clear=True)
+    def test_host_and_skip_ssl_verify_via_override(self, mock_requests):
+        # host/skip_ssl_verify are first-class Config fields, settable through
+        # any channel -- here as explicit overrides, not just env vars.
+        coveralls.Coveralls(
+            repo_token='xxx',
+            coveralls_host='https://coveralls.my-enterprise.info',
+            skip_ssl_verify=True,
+        ).wear(dry_run=False)
+        mock_requests.post.assert_called_once_with(
+            'https://coveralls.my-enterprise.info/api/v1/jobs',
+            files=unittest.mock.ANY, verify=False, timeout=(10, 60),
+        )
+
+    @unittest.mock.patch.dict(os.environ, {}, clear=True)
     def test_api_call_uses_default_host_if_no_env_var_set(self, mock_requests):
         coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
         mock_requests.post.assert_called_once_with(


### PR DESCRIPTION
## Summary

`resolve()` now returns a typed `Config` dataclass instead of an untyped dict.

## Changes

- `Config` dataclass splits API **payload fields** from **client-behaviour
  settings**, with `to_payload()` as the enforced boundary (superseding the
  manual allowlist filter in `create_data()`).
- `request_timeout` resolves the `(connect, read)` tuple; the timeout family is
  validated at construction.
- Unknown config-file keys are dropped with a warning against the known field
  set.
- `api.py` consumes `Config` by attribute and is now type-checked (mypy passes).

Field names are unchanged here (`coveralls_host`, `config_file`); the rename to
consistent spellings is the final PR.

## Stack

PR **3 of 4** splitting #752. Based on #754.