### PR TITLE
refactor(cli): consistent setting names across every interface

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -27,8 +27,7 @@ class Coveralls:
         Initialize the main Coveralls collection entrypoint.
 
         Keyword arguments are treated as explicit config overrides (highest
-        precedence) and merged with the CI environment, ``COVERALLS_*`` env
-        vars, and the config file by :func:`resolve`, e.g.:
+        precedence) and must be valid :class:`Config` fields, e.g.:
 
         * repo_token
           The secret token for your repository, found at the bottom of your
@@ -80,8 +79,7 @@ class Coveralls:
         return self.submit_report(json_string)
 
     def submit_report(self, json_string):
-        host = self.config.coveralls_host.rstrip('/')
-        endpoint = f'{host}/api/v1/jobs'
+        endpoint = f'{self.config.host.rstrip("/")}/api/v1/jobs'
         verify = not self.config.skip_ssl_verify
         timeout = self.config.request_timeout
         try:
@@ -133,8 +131,7 @@ class Coveralls:
             # Github Actions only
             payload['repo_name'] = os.environ.get('GITHUB_REPOSITORY')
 
-        host = self.config.coveralls_host.rstrip('/')
-        endpoint = f'{host}/webhook'
+        endpoint = f'{self.config.host.rstrip("/")}/webhook'
         verify = not self.config.skip_ssl_verify
         timeout = self.config.request_timeout
         try:
@@ -237,7 +234,7 @@ class Coveralls:
         return self._data
 
     def get_coverage(self):
-        work = coverage.coverage(config_file=self.config.config_file)
+        work = coverage.coverage(config_file=self.config.rcfile)
         work.load()
         work.get_data()
 

--- a/coveralls/cli.py
+++ b/coveralls/cli.py
@@ -2,6 +2,7 @@ import importlib.metadata
 import logging
 import sys
 from typing import Annotated
+from typing import Any
 
 import typer
 
@@ -27,10 +28,10 @@ Example:
   Coverage submitted!
 """
 DEBUG_HELP = (
-    "Debug mode doesn't send anything, just outputs json to stdout. "
-    'It also forces verbose output. Please use debug mode when submitting '
-    'bug reports.'
+    "Don't send anything, just output json to stdout. Also forces verbose "
+    'output. Please use debug mode when submitting bug reports.'
 )
+
 
 app = typer.Typer(
     add_completion=True,
@@ -45,53 +46,70 @@ def _show_version(value: bool) -> None:
         raise typer.Exit()
 
 
+def _configure_logging(*, verbose: bool) -> None:
+    # Guard against duplicate handlers: main() may be invoked more than once in
+    # the same process (tests, library reuse) and each StreamHandler would
+    # otherwise stack up and multiply the output.
+    if not log.handlers:
+        log.addHandler(logging.StreamHandler())
+    log.setLevel(logging.DEBUG if verbose else logging.INFO)
+
+
+def _resolve_deprecated(
+    new: str | None, old: str | None,
+    new_flag: str, old_flag: str,
+) -> str | None:
+    """Prefer the canonical value, warning when the deprecated flag is used."""
+    if old is None:
+        return new
+    log.warning(
+        '%s is deprecated and will be removed in a future release; use %s '
+        'instead.', old_flag, new_flag,
+    )
+    return new if new is not None else old
+
+
 def _run(
     *,
     is_debug: bool,
-    service: str | None,
-    rcfile: str,
-    basedir: str | None,
+    service_name: str | None,
+    rcfile: str | None,
+    base_dir: str | None,
+    src_dir: str | None,
     output: str | None,
-    srcdir: str | None,
     submit: str | None,
     merge: str | None,
     finish: bool,
-    verbose: bool,
+    parallel: bool | None,
+    host: str | None,
+    skip_ssl_verify: bool | None,
     timeout: float | None,
     connect_timeout: float | None,
     read_timeout: float | None,
 ) -> None:
     # pylint: disable=too-complex,too-many-locals,too-many-arguments
-    if is_debug:
-        verbose = True
-
-    level = logging.DEBUG if verbose else logging.INFO
-    log.addHandler(logging.StreamHandler())
-    log.setLevel(level)
-
     token_required = not is_debug and not output
 
-    # Only forward timeouts that were explicitly set so CLI defaults (None)
-    # don't clobber values already resolved from env vars or the config file.
-    timeout_kwargs = {
-        key: value
-        for key, value in (
-            ('timeout', timeout),
-            ('connect_timeout', connect_timeout),
-            ('read_timeout', read_timeout),
-        )
-        if value is not None
+    # Forward every CLI value as-is and let resolve() own precedence: it drops
+    # the ones left unset (None) so a flag that was not passed cannot clobber a
+    # value from the environment or config file. Passing an explicit value
+    # (including a False from --no-parallel/--no-skip-ssl-verify) overrides,
+    # keeping the CLI and library entrypoints on identical precedence rules.
+    overrides: dict[str, Any] = {
+        'rcfile': rcfile,
+        'service_name': service_name,
+        'base_dir': base_dir,
+        'src_dir': src_dir,
+        'host': host,
+        'parallel': parallel,
+        'skip_ssl_verify': skip_ssl_verify,
+        'timeout': timeout,
+        'connect_timeout': connect_timeout,
+        'read_timeout': read_timeout,
     }
 
     try:
-        coverallz = Coveralls(
-            token_required,
-            config_file=rcfile,
-            service_name=service,
-            base_dir=basedir or '',
-            src_dir=srcdir or '',
-            **timeout_kwargs,
-        )
+        coverallz = Coveralls(token_required, **overrides)
 
         if merge:
             coverallz.merge(merge)
@@ -132,110 +150,224 @@ def _run(
         sys.exit(1)
 
 
-@app.callback(invoke_without_command=True)
-def coveralls(
-    ctx: typer.Context,
-    service: Annotated[
-        str | None,
-        typer.Option(
-            '--service',
-            help='Provide an alternative service name to submit.',
-        ),
-    ] = None,
-    rcfile: Annotated[
-        str,
-        typer.Option('--rcfile', help='Specify configuration file.'),
-    ] = '.coveragerc',
-    basedir: Annotated[
-        str | None,
-        typer.Option(
-            '--basedir',
-            help='Base directory that is removed from reported paths.',
-        ),
-    ] = None,
-    output: Annotated[
-        str | None,
-        typer.Option(
-            '--output',
-            help="Write report to file. Doesn't send anything.",
-        ),
-    ] = None,
-    srcdir: Annotated[
-        str | None,
-        typer.Option(
-            '--srcdir',
-            help='Source directory added to reported paths.',
-        ),
-    ] = None,
-    submit: Annotated[
-        str | None,
-        typer.Option('--submit', help='Upload a previously generated file.'),
-    ] = None,
-    merge: Annotated[
-        str | None,
-        typer.Option(
-            '--merge',
-            help='Merge report from file when submitting.',
-        ),
-    ] = None,
-    finish: Annotated[
-        bool,
-        typer.Option('--finish', help='Finish parallel jobs.'),
-    ] = False,
-    verbose: Annotated[
-        bool,
-        typer.Option(
-            '-v',
-            '--verbose',
-            help='Print extra info, always enabled when debugging.',
-        ),
-    ] = False,
-    version: Annotated[
-        bool | None,
-        typer.Option(
-            '--version',
-            callback=_show_version,
-            help='Display the version and exit.',
-            is_eager=True,
-        ),
-    ] = None,
-    timeout: Annotated[
-        float | None,
-        typer.Option(
-            '--timeout',
-            help='Connect and read timeout, in seconds (default: 10/60).',
-        ),
-    ] = None,
-    connect_timeout: Annotated[
-        float | None,
-        typer.Option(
-            '--connect-timeout',
-            help='Connect timeout, in seconds (default: 10).',
-        ),
-    ] = None,
-    read_timeout: Annotated[
-        float | None,
-        typer.Option(
-            '--read-timeout',
-            help='Read timeout, in seconds (default: 60).',
-        ),
-    ] = None,
-) -> None:
-    # pylint: disable=too-many-arguments,too-many-positional-arguments
-    if ctx.invoked_subcommand is not None:
-        return
+# Shared option specs, defined once and referenced by both the default command
+# and the ``debug`` subcommand so the two entry points cannot drift apart.
+_ServiceName = Annotated[
+    str | None,
+    typer.Option(
+        '--service-name',
+        help='Provide an alternative service name to submit.',
+    ),
+]
+_Service = Annotated[
+    str | None,
+    typer.Option(
+        '--service', hidden=True, help='Deprecated alias for --service-name.',
+    ),
+]
+_Rcfile = Annotated[
+    str | None,
+    typer.Option(
+        '--rcfile',
+        help='Specify the coverage.py config file (default: auto-discovered).',
+    ),
+]
+_BaseDir = Annotated[
+    str | None,
+    typer.Option(
+        '--base-dir',
+        help='Base directory that is removed from reported paths.',
+    ),
+]
+_Basedir = Annotated[
+    str | None,
+    typer.Option(
+        '--basedir', hidden=True, help='Deprecated alias for --base-dir.',
+    ),
+]
+_SrcDir = Annotated[
+    str | None,
+    typer.Option(
+        '--src-dir', help='Source directory added to reported paths.',
+    ),
+]
+_Srcdir = Annotated[
+    str | None,
+    typer.Option(
+        '--srcdir', hidden=True, help='Deprecated alias for --src-dir.',
+    ),
+]
+_Output = Annotated[
+    str | None,
+    typer.Option(
+        '--output', help="Write report to file. Doesn't send "
+        'anything.',
+    ),
+]
+_Submit = Annotated[
+    str | None,
+    typer.Option('--submit', help='Upload a previously generated file.'),
+]
+_Merge = Annotated[
+    str | None,
+    typer.Option('--merge', help='Merge report from file when submitting.'),
+]
+_Finish = Annotated[
+    bool,
+    typer.Option('--finish', help='Finish parallel jobs.'),
+]
+_Parallel = Annotated[
+    bool | None,
+    typer.Option(
+        '--parallel/--no-parallel',
+        help='Submit as one of several parallel jobs to be merged.',
+    ),
+]
+_Host = Annotated[
+    str | None,
+    typer.Option('--host', help='Coveralls API host base URL.'),
+]
+_SkipSslVerify = Annotated[
+    bool | None,
+    typer.Option(
+        '--skip-ssl-verify/--no-skip-ssl-verify',
+        help='Skip verification of the SSL certificate of the host.',
+    ),
+]
+_Verbose = Annotated[
+    bool,
+    typer.Option(
+        '-v', '--verbose',
+        help='Print extra info, always enabled when debugging.',
+    ),
+]
+_Timeout = Annotated[
+    float | None,
+    typer.Option(
+        '--timeout',
+        help='Connect and read timeout, in seconds (default: 10/60).',
+    ),
+]
+_ConnectTimeout = Annotated[
+    float | None,
+    typer.Option(
+        '--connect-timeout', help='Connect timeout, in seconds (default: 10).',
+    ),
+]
+_ReadTimeout = Annotated[
+    float | None,
+    typer.Option(
+        '--read-timeout', help='Read timeout, in seconds (default: 60).',
+    ),
+]
+_Version = Annotated[
+    bool | None,
+    typer.Option(
+        '--version', callback=_show_version, is_eager=True,
+        help='Display the version and exit.',
+    ),
+]
 
-    _ = version
+
+def _dispatch(
+    *,
+    is_debug: bool,
+    service_name: str | None,
+    service: str | None,
+    rcfile: str | None,
+    base_dir: str | None,
+    basedir: str | None,
+    src_dir: str | None,
+    srcdir: str | None,
+    output: str | None,
+    submit: str | None,
+    merge: str | None,
+    finish: bool,
+    parallel: bool | None,
+    host: str | None,
+    skip_ssl_verify: bool | None,
+    verbose: bool,
+    timeout: float | None,
+    connect_timeout: float | None,
+    read_timeout: float | None,
+) -> None:
+    # pylint: disable=too-many-arguments,too-many-locals
+    # Configure logging before resolving deprecated aliases so their warnings
+    # go through the same handler as the config-layer deprecation warnings
+    # emitted later during Coveralls() construction.
+    _configure_logging(verbose=verbose or is_debug)
+
+    service_name = _resolve_deprecated(
+        service_name, service, '--service-name', '--service',
+    )
+    base_dir = _resolve_deprecated(
+        base_dir, basedir, '--base-dir', '--basedir',
+    )
+    src_dir = _resolve_deprecated(src_dir, srcdir, '--src-dir', '--srcdir')
+
     _run(
-        is_debug=False,
-        service=service,
+        is_debug=is_debug,
+        service_name=service_name,
         rcfile=rcfile,
-        basedir=basedir,
+        base_dir=base_dir,
+        src_dir=src_dir,
         output=output,
-        srcdir=srcdir,
         submit=submit,
         merge=merge,
         finish=finish,
+        parallel=parallel,
+        host=host,
+        skip_ssl_verify=skip_ssl_verify,
+        timeout=timeout,
+        connect_timeout=connect_timeout,
+        read_timeout=read_timeout,
+    )
+
+
+@app.callback(invoke_without_command=True)
+def coveralls(
+    ctx: typer.Context,
+    service_name: _ServiceName = None,
+    service: _Service = None,
+    rcfile: _Rcfile = None,
+    base_dir: _BaseDir = None,
+    basedir: _Basedir = None,
+    src_dir: _SrcDir = None,
+    srcdir: _Srcdir = None,
+    output: _Output = None,
+    submit: _Submit = None,
+    merge: _Merge = None,
+    finish: _Finish = False,
+    parallel: _Parallel = None,
+    host: _Host = None,
+    skip_ssl_verify: _SkipSslVerify = None,
+    verbose: _Verbose = False,
+    timeout: _Timeout = None,
+    connect_timeout: _ConnectTimeout = None,
+    read_timeout: _ReadTimeout = None,
+    version: _Version = None,
+) -> None:
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
+    # pylint: disable=too-many-locals
+    if ctx.invoked_subcommand is not None:
+        return
+    _ = version
+    _dispatch(
+        is_debug=False,
+        service_name=service_name,
+        service=service,
+        rcfile=rcfile,
+        base_dir=base_dir,
+        basedir=basedir,
+        src_dir=src_dir,
+        srcdir=srcdir,
+        output=output,
+        submit=submit,
+        merge=merge,
+        finish=finish,
+        parallel=parallel,
+        host=host,
+        skip_ssl_verify=skip_ssl_verify,
         verbose=verbose,
         timeout=timeout,
         connect_timeout=connect_timeout,
@@ -245,104 +377,45 @@ def coveralls(
 
 @app.command(help=DEBUG_HELP)
 def debug(
-    service: Annotated[
-        str | None,
-        typer.Option(
-            '--service',
-            help='Provide an alternative service name to submit.',
-        ),
-    ] = None,
-    rcfile: Annotated[
-        str,
-        typer.Option('--rcfile', help='Specify configuration file.'),
-    ] = '.coveragerc',
-    basedir: Annotated[
-        str | None,
-        typer.Option(
-            '--basedir',
-            help='Base directory that is removed from reported paths.',
-        ),
-    ] = None,
-    output: Annotated[
-        str | None,
-        typer.Option(
-            '--output',
-            help="Write report to file. Doesn't send anything.",
-        ),
-    ] = None,
-    srcdir: Annotated[
-        str | None,
-        typer.Option(
-            '--srcdir',
-            help='Source directory added to reported paths.',
-        ),
-    ] = None,
-    submit: Annotated[
-        str | None,
-        typer.Option('--submit', help='Upload a previously generated file.'),
-    ] = None,
-    merge: Annotated[
-        str | None,
-        typer.Option(
-            '--merge',
-            help='Merge report from file when submitting.',
-        ),
-    ] = None,
-    finish: Annotated[
-        bool,
-        typer.Option('--finish', help='Finish parallel jobs.'),
-    ] = False,
-    verbose: Annotated[
-        bool,
-        typer.Option(
-            '-v',
-            '--verbose',
-            help='Print extra info, always enabled when debugging.',
-        ),
-    ] = False,
-    version: Annotated[
-        bool | None,
-        typer.Option(
-            '--version',
-            callback=_show_version,
-            help='Display the version and exit.',
-            is_eager=True,
-        ),
-    ] = None,
-    timeout: Annotated[
-        float | None,
-        typer.Option(
-            '--timeout',
-            help='Connect and read timeout, in seconds (default: 10/60).',
-        ),
-    ] = None,
-    connect_timeout: Annotated[
-        float | None,
-        typer.Option(
-            '--connect-timeout',
-            help='Connect timeout, in seconds (default: 10).',
-        ),
-    ] = None,
-    read_timeout: Annotated[
-        float | None,
-        typer.Option(
-            '--read-timeout',
-            help='Read timeout, in seconds (default: 60).',
-        ),
-    ] = None,
+    service_name: _ServiceName = None,
+    service: _Service = None,
+    rcfile: _Rcfile = None,
+    base_dir: _BaseDir = None,
+    basedir: _Basedir = None,
+    src_dir: _SrcDir = None,
+    srcdir: _Srcdir = None,
+    output: _Output = None,
+    submit: _Submit = None,
+    merge: _Merge = None,
+    finish: _Finish = False,
+    parallel: _Parallel = None,
+    host: _Host = None,
+    skip_ssl_verify: _SkipSslVerify = None,
+    verbose: _Verbose = False,
+    timeout: _Timeout = None,
+    connect_timeout: _ConnectTimeout = None,
+    read_timeout: _ReadTimeout = None,
+    version: _Version = None,
 ) -> None:
     # pylint: disable=too-many-arguments,too-many-positional-arguments
+    # pylint: disable=too-many-locals
     _ = version
-    _run(
+    _dispatch(
         is_debug=True,
+        service_name=service_name,
         service=service,
         rcfile=rcfile,
+        base_dir=base_dir,
         basedir=basedir,
-        output=output,
+        src_dir=src_dir,
         srcdir=srcdir,
+        output=output,
         submit=submit,
         merge=merge,
         finish=finish,
+        parallel=parallel,
+        host=host,
+        skip_ssl_verify=skip_ssl_verify,
         verbose=verbose,
         timeout=timeout,
         connect_timeout=connect_timeout,
@@ -350,6 +423,6 @@ def debug(
     )
 
 
-def main(argv=None):
+def main(argv: list[str] | None = None) -> None:
     command = typer.main.get_command(app)
     command.main(args=argv, prog_name='coveralls', standalone_mode=False)

--- a/coveralls/configuration.py
+++ b/coveralls/configuration.py
@@ -81,13 +81,13 @@ class Config:
     run_at: str | None = None
 
     # client settings
-    coveralls_host: str = DEFAULT_HOST
+    host: str = DEFAULT_HOST
     skip_ssl_verify: bool = False
     token_required: bool = True
     base_dir: str = ''
     src_dir: str = ''
     # True lets coverage.py auto-discover its config file; a str names one.
-    config_file: str | bool = True
+    rcfile: str | bool = True
     timeout: float | None = None
     connect_timeout: float | None = None
     read_timeout: float | None = None
@@ -152,6 +152,24 @@ class Config:
 
 
 _FIELD_NAMES = frozenset(f.name for f in dataclasses.fields(Config))
+
+# Config keys (in the config file or as Coveralls() kwargs) that were renamed
+# for naming consistency. The old spelling still works but warns, mirroring the
+# deprecated CLI flag aliases.
+# Permanent alternate spellings accepted in the config file and as Coveralls()
+# keyword arguments. Both the canonical name and the alias are long-term
+# supported and neither warns: ``coveralls_host`` reads more clearly in a
+# .coveralls.yml, while ``host`` matches the ``COVERALLS_HOST`` env var and
+# ``--host`` flag.
+ALIASES = {
+    'coveralls_host': 'host',
+}
+
+# Renamed keys still accepted for backwards-compatibility but deprecated: they
+# warn and will be removed in a future release.
+DEPRECATED_KEYS = {
+    'config_file': 'rcfile',
+}
 
 
 def _parse_pr_number(value: str | None) -> str | None:
@@ -289,21 +307,24 @@ def _from_environment() -> dict[str, Any]:
 
     host = os.environ.get('COVERALLS_HOST')
     if host:
-        config['coveralls_host'] = host
+        config['host'] = host
     if os.environ.get('COVERALLS_PARALLEL', '').lower() == 'true':
         config['parallel'] = True
     if os.environ.get('COVERALLS_SKIP_SSL_VERIFY'):
         config['skip_ssl_verify'] = True
 
     fields = {
+        'COVERALLS_BASE_DIR': 'base_dir',
         'COVERALLS_CONNECT_TIMEOUT': 'connect_timeout',
         'COVERALLS_FLAG_NAME': 'flag_name',
+        'COVERALLS_RCFILE': 'rcfile',
         'COVERALLS_READ_TIMEOUT': 'read_timeout',
         'COVERALLS_REPO_TOKEN': 'repo_token',
         'COVERALLS_SERVICE_JOB_ID': 'service_job_id',
         'COVERALLS_SERVICE_JOB_NUMBER': 'service_job_number',
         'COVERALLS_SERVICE_NAME': 'service_name',
         'COVERALLS_SERVICE_NUMBER': 'service_number',
+        'COVERALLS_SRC_DIR': 'src_dir',
         'COVERALLS_TIMEOUT': 'timeout',
     }
     for var, key in fields.items():
@@ -312,6 +333,31 @@ def _from_environment() -> dict[str, Any]:
             config[key] = value
 
     return config
+
+
+def _canonicalize_keys(
+    data: Mapping[str, Any], *, source: str,
+) -> dict[str, Any]:
+    """
+    Map alias/deprecated keys to their canonical names.
+
+    Permanent aliases are mapped silently; deprecated keys additionally warn.
+    An explicit canonical key in the same source always takes precedence.
+    """
+    result: dict[str, Any] = {}
+    for key, value in data.items():
+        canonical = ALIASES.get(key) or DEPRECATED_KEYS.get(key)
+        if canonical is None:
+            result[key] = value
+            continue
+        if key in DEPRECATED_KEYS:
+            log.warning(
+                '%r is deprecated and will be removed in a future release; '
+                'use %r instead (in %s).', key, canonical, source,
+            )
+        if canonical not in data:
+            result[canonical] = value
+    return result
 
 
 def _filter_known(data: Mapping[str, Any], *, source: str) -> dict[str, Any]:
@@ -341,8 +387,9 @@ def _from_file(config_filename: str) -> dict[str, Any]:
         )
         return {}
 
-    # yaml.safe_load() returns None for an empty or comment-only file.
-    data = yaml.safe_load(content) or {}
+    data = _canonicalize_keys(
+        yaml.safe_load(content) or {}, source=config_filename,
+    )
     return _filter_known(data, source=config_filename)
 
 
@@ -365,6 +412,7 @@ def resolve(
     that authenticates uploads itself. A ``token_required`` key in the config
     file or environment is therefore ignored.
     """
+    overrides = _canonicalize_keys(overrides, source='arguments')
     cleaned = _filter_known(
         {
             key: value for key, value in overrides.items()

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -29,9 +29,21 @@ If you have placed your ``.coveragerc`` in a non-standard location (ie. other th
 
 If you would like to override the service name (auto-discovered on most CI systems, set to ``coveralls-python`` otherwise)::
 
-    coveralls --service=travis-pro
+    coveralls --service-name=travis-pro
     # or, via env var:
     COVERALLS_SERVICE_NAME=travis-pro coveralls
+
+.. note::
+
+    Configuration options follow a single naming convention: wherever a
+    setting ``foo_bar`` is available it is spelled ``--foo-bar`` as a CLI flag,
+    ``COVERALLS_FOO_BAR`` as an environment variable, and ``foo_bar`` in the
+    config file. Not every setting is exposed on every interface (for example,
+    the CI-detected ``service_branch`` has no CLI flag), but where it is, the
+    name is derived the same way. The ``--service``, ``--basedir`` and
+    ``--srcdir`` flags were renamed to ``--service-name``, ``--base-dir`` and
+    ``--src-dir`` to match; the old spellings still work but are deprecated
+    and will be removed in a future release.
 
 If you are interested in merging the coverage results between multiple languages/projects, see our :ref:`multi-language <multilang>` documentation.
 
@@ -42,18 +54,24 @@ If coveralls-python is being run on TravisCI or on GitHub Actions, it will autom
 If you are running multiple jobs in parallel and want coveralls.io to merge those results, you should set ``COVERALLS_PARALLEL`` to ``true`` in your environment::
 
     COVERALLS_PARALLEL=true coveralls
+    # or, via CLI flag:
+    coveralls --parallel
 
 Later on, you can use ``coveralls --finish`` to let the Coveralls service know you have completed all your parallel runs::
 
     coveralls --finish
 
-If you are using a non-public coveralls.io instance (for example: self-hosted Coveralls Enterprise), you can set ``COVERALLS_HOST`` to the base URL of that insance::
+If you are using a non-public coveralls.io instance (for example: self-hosted Coveralls Enterprise), you can set the host to the base URL of that instance::
 
     COVERALLS_HOST="https://coveralls.aperture.com" coveralls
+    # or, via CLI flag:
+    coveralls --host=https://coveralls.aperture.com
 
 In that case, you may also be interested in disabling SSL verification::
 
     COVERALLS_SKIP_SSL_VERIFY='1' coveralls
+    # or, via CLI flag:
+    coveralls --skip-ssl-verify
 
 Network requests to coveralls.io use a default connect timeout of 10 seconds and a read timeout of 60 seconds, so a stalled endpoint can never hang the CLI indefinitely. You can override these via env vars or CLI flags::
 
@@ -77,10 +95,21 @@ Sample ``.coveralls.yml`` file::
     service_name: travis-pro
     repo_token: mV2Jajb8y3c6AFlcVNagHO20fiZNkXPVy
     parallel: true
-    coveralls_host: https://coveralls.aperture.com
+    host: https://coveralls.aperture.com
     timeout: 30
     connect_timeout: 5
     read_timeout: 90
+
+.. note::
+
+    ``coveralls_host`` and ``host`` are both accepted (in ``.coveralls.yml``
+    and as ``Coveralls()`` keyword arguments) and are equivalent long-term
+    spellings -- ``coveralls_host`` reads more clearly in a config file, while
+    ``host`` matches the ``COVERALLS_HOST`` environment variable and ``--host``
+    flag. The ``config_file`` key was renamed to ``rcfile`` for consistency;
+    the old spelling still works but is deprecated, emits a warning, and will
+    be removed in a future release. Other unrecognised keys are ignored with a
+    warning.
 
 Github Actions support
 ----------------------
@@ -94,14 +123,14 @@ pass the default-provided secret GITHUB_TOKEN::
 
 Passing a coveralls.io token via the ``COVERALLS_REPO_TOKEN`` environment variable
 (or via the ``repo_token`` parameter in the config file) is not needed for
-Github Actions by default (eg. with the default value of ``--service=github``).
+Github Actions by default (eg. with the default value of ``--service-name=github``).
 
 Github Actions can get a bit finicky as to how coverage is submitted. If you
 find yourself getting 422 error responses, you can also try specifying the
 ``github-actions`` service name instead. If you do so, you will need to proved
 a ``COVERALLS_REPO_TOKEN`` *instead* of a ``GITHUB_TOKEN``::
 
-    run: coveralls --service=github-actions
+    run: coveralls --service-name=github-actions
     env:
         COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
 

--- a/tests/api/config_test.py
+++ b/tests/api/config_test.py
@@ -16,12 +16,12 @@ def test_defaults():
     assert config.service_name == 'coveralls-python'
     assert config.parallel is None
     assert config.run_at is None
-    assert config.coveralls_host == DEFAULT_HOST
+    assert config.host == DEFAULT_HOST
     assert config.skip_ssl_verify is False
     assert config.token_required is True
     assert config.base_dir == ''
     assert config.src_dir == ''
-    assert config.config_file is True
+    assert config.rcfile is True
     assert config.timeout is None
     assert config.connect_timeout is None
     assert config.read_timeout is None
@@ -56,12 +56,12 @@ def test_to_payload_forwards_explicitly_set_falsey_fields():
 # listed here. test_payload_and_client_fields_..._cover_the_dataclass enforces
 # this, so add new fields to one list or the other.
 CLIENT_ONLY_FIELDS = (
-    'coveralls_host',
+    'host',
     'skip_ssl_verify',
     'token_required',
     'base_dir',
     'src_dir',
-    'config_file',
+    'rcfile',
     'timeout',
     'connect_timeout',
     'read_timeout',
@@ -69,15 +69,15 @@ CLIENT_ONLY_FIELDS = (
 
 
 def test_client_settings_never_leak_into_payload():
-    # Regression guard: base_dir/src_dir/config_file and the timeout family
-    # have all historically leaked into the submitted JSON via a config bag.
+    # Regression guard: base_dir/src_dir/rcfile and the timeout family have all
+    # historically leaked into the submitted JSON via an untyped config bag.
     payload = Config(
         repo_token='xxx',
-        coveralls_host='https://enterprise.example.com',
+        host='https://enterprise.example.com',
         skip_ssl_verify=True,
         base_dir='b',
         src_dir='s',
-        config_file='.coveragerc',
+        rcfile='.coveragerc',
         timeout=30,
         connect_timeout=5,
         read_timeout=25,

--- a/tests/api/configuration_test.py
+++ b/tests/api/configuration_test.py
@@ -43,7 +43,7 @@ class TestConfigIntegration:
     def test_reads_environment(self):
         cover = Coveralls()
 
-        assert cover.config.coveralls_host == 'https://enterprise.example.com'
+        assert cover.config.host == 'https://enterprise.example.com'
         assert cover.config.parallel is True
         assert cover.config.repo_token == 'a1b2c3d4'
         assert cover.config.service_name == 'bbb'
@@ -53,12 +53,12 @@ class TestConfigIntegration:
         cover = Coveralls(
             repo_token='yyy',
             service_name='coveralls-aaa',
-            coveralls_host='https://coveralls.aaa.com',
+            host='https://coveralls.aaa.com',
         )
 
         assert cover.config.repo_token == 'yyy'
         assert cover.config.service_name == 'coveralls-aaa'
-        assert cover.config.coveralls_host == 'https://coveralls.aaa.com'
+        assert cover.config.host == 'https://coveralls.aaa.com'
 
     @unittest.mock.patch.dict(
         os.environ,

--- a/tests/api/resolve_test.py
+++ b/tests/api/resolve_test.py
@@ -265,12 +265,15 @@ def test_generic_ci_name_wins_over_specific_service():
         'COVERALLS_SERVICE_JOB_NUMBER': '1234',
         'COVERALLS_SKIP_SSL_VERIFY': '1',
         'COVERALLS_TIMEOUT': '30',
+        'COVERALLS_RCFILE': 'custom.rc',
+        'COVERALLS_BASE_DIR': 'base',
+        'COVERALLS_SRC_DIR': 'src',
     },
     clear=True,
 )
 def test_environment_variables():
     config = resolve_config()
-    assert config.coveralls_host == 'https://enterprise.example.com'
+    assert config.host == 'https://enterprise.example.com'
     assert config.parallel is True
     assert config.repo_token == 'a1b2c3d4'
     assert config.service_name == 'bbb'
@@ -278,15 +281,17 @@ def test_environment_variables():
     assert config.service_job_number == '1234'
     assert config.skip_ssl_verify is True
     assert config.timeout == 30.0
+    # base_dir/src_dir/rcfile complete the convention on the env interface
+    assert config.rcfile == 'custom.rc'
+    assert config.base_dir == 'base'
+    assert config.src_dir == 'src'
 
 
 @unittest.mock.patch.dict(os.environ, {}, clear=True)
 def test_overrides_win_over_environment():
     with unittest.mock.patch.dict(os.environ, {'COVERALLS_HOST': 'env'}):
-        config = resolve_config(
-            coveralls_host='cli', service_name='cli-service',
-        )
-    assert config.coveralls_host == 'cli'
+        config = resolve_config(host='cli', service_name='cli-service')
+    assert config.host == 'cli'
     assert config.service_name == 'cli-service'
 
 
@@ -399,6 +404,39 @@ def test_resolve_returns_config_instance():
     assert isinstance(resolve_config(), Config)
 
 
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_coveralls_host_alias_is_permanent_and_silent():
+    # coveralls_host and host are both long-term spellings; the alias maps to
+    # host and must NOT emit a deprecation warning.
+    with unittest.mock.patch.object(log, 'warning') as warning:
+        config = resolve_config(
+            repo_token='x', coveralls_host='https://old.example.com',
+        )
+    assert config.host == 'https://old.example.com'
+    warning.assert_not_called()
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_deprecated_config_file_key_warns():
+    with unittest.mock.patch.object(log, 'warning') as warning:
+        config = resolve_config(repo_token='x', config_file='custom.rc')
+    assert config.rcfile == 'custom.rc'
+    warning.assert_called_once_with(
+        '%r is deprecated and will be removed in a future release; use %r '
+        'instead (in %s).', 'config_file', 'rcfile', 'arguments',
+    )
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_alias_does_not_override_explicit_canonical():
+    config = resolve_config(
+        repo_token='x',
+        host='https://new.example.com',
+        coveralls_host='https://old.example.com',
+    )
+    assert config.host == 'https://new.example.com'
+
+
 @pytest.mark.skipif(yaml is None, reason='requires PyYAML')
 @pytest.mark.parametrize('content', ['', '\n\n', '# only a comment\n'])
 @unittest.mock.patch.dict(os.environ, {}, clear=True)
@@ -416,12 +454,33 @@ def test_empty_config_file_is_ignored(content, tmp_path, monkeypatch):
 
 @pytest.mark.skipif(yaml is None, reason='requires PyYAML')
 @unittest.mock.patch.dict(os.environ, {}, clear=True)
-def test_none_config_file_override_keeps_file_value(tmp_path, monkeypatch):
-    # The CLI forwards config_file=None when unset; that must not override a
-    # config_file set in the config file.
+def test_none_rcfile_override_keeps_file_value(tmp_path, monkeypatch):
+    # The CLI forwards rcfile=None when --rcfile is not passed; that must not
+    # override an rcfile/config_file set in the config file.
     monkeypatch.chdir(tmp_path)
     (tmp_path / '.coveralls.mock').write_text(
         'repo_token: xxx\nconfig_file: from_yaml.rc\n',
     )
-    config = resolve('.coveralls.mock', {'config_file': None})
-    assert config.config_file == 'from_yaml.rc'
+    config = resolve('.coveralls.mock', {'rcfile': None})
+    assert config.rcfile == 'from_yaml.rc'
+
+
+@pytest.mark.skipif(yaml is None, reason='requires PyYAML')
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_alias_and_deprecated_file_keys_still_work(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / '.coveralls.mock').write_text(
+        'repo_token: xxx\n'
+        'coveralls_host: https://old.example.com\n'
+        'config_file: custom.rc\n',
+    )
+    with unittest.mock.patch.object(log, 'warning') as warning:
+        config = resolve('.coveralls.mock', {})
+
+    assert config.host == 'https://old.example.com'
+    assert config.rcfile == 'custom.rc'
+    # config_file is deprecated (warns); coveralls_host is a permanent alias.
+    warning.assert_called_once_with(
+        '%r is deprecated and will be removed in a future release; use %r '
+        'instead (in %s).', 'config_file', 'rcfile', '.coveralls.mock',
+    )

--- a/tests/api/wear_test.py
+++ b/tests/api/wear_test.py
@@ -33,14 +33,15 @@ class WearTest(unittest.TestCase):
 
     @unittest.mock.patch.dict(os.environ, {}, clear=True)
     def test_client_settings_do_not_leak_into_payload(self, _mock_requests):
-        # Regression guard: base_dir/src_dir/config_file and the timeout family
-        # are client-only settings and must never enter the submitted JSON.
+        # Regression guard at the create_data() boundary: base_dir/src_dir/
+        # rcfile and the timeout family are client-only and must never enter
+        # the submitted JSON.
         api = coveralls.Coveralls(
             repo_token='xxx',
             service_name='travis-ci',
             base_dir='foo',
             src_dir='bar',
-            config_file='.coveragerc',
+            rcfile='.coveragerc',
             timeout=30,
             connect_timeout=5,
             read_timeout=25,
@@ -49,7 +50,7 @@ class WearTest(unittest.TestCase):
             data = api.create_data()
 
         for leaked in (
-            'base_dir', 'src_dir', 'config_file',
+            'base_dir', 'src_dir', 'rcfile', 'config_file',
             'timeout', 'connect_timeout', 'read_timeout',
         ):
             assert leaked not in data
@@ -173,7 +174,7 @@ class WearTest(unittest.TestCase):
         # any channel -- here as explicit overrides, not just env vars.
         coveralls.Coveralls(
             repo_token='xxx',
-            coveralls_host='https://coveralls.my-enterprise.info',
+            host='https://coveralls.my-enterprise.info',
             skip_ssl_verify=True,
         ).wear(dry_run=False)
         mock_requests.post.assert_called_once_with(

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -20,6 +20,32 @@ def req_json(request):
     return json.loads(request.body.decode('utf-8'))
 
 
+def coveralls_kwargs(**overrides):
+    """Expected Coveralls() override kwargs: everything unset (None) initially.
+
+    The CLI forwards every value as-is and lets resolve() drop the unset ones,
+    so the constructor is always called with the full override set.
+
+    Keep this in sync with the CLI option set: a new forwarded option must be
+    added here, otherwise every test that uses the default set will silently
+    under-assert on it.
+    """
+    kwargs = {
+        'rcfile': None,
+        'service_name': None,
+        'base_dir': None,
+        'src_dir': None,
+        'host': None,
+        'parallel': None,
+        'skip_ssl_verify': None,
+        'timeout': None,
+        'connect_timeout': None,
+        'read_timeout': None,
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
 @mock.patch.dict(os.environ, {'TRAVIS': 'True'}, clear=True)
 @mock.patch.object(coveralls.cli.log, 'info')
 @mock.patch.object(coveralls.Coveralls, 'wear')
@@ -36,6 +62,16 @@ def test_debug_no_token(mock_wear, mock_log):
     coveralls.cli.main(argv=['debug'])
     mock_wear.assert_called_with(dry_run=True)
     mock_log.assert_has_calls([mock.call('Testing coveralls-python...')])
+
+
+@mock.patch.dict(os.environ, {'TRAVIS': 'True'}, clear=True)
+@mock.patch('coveralls.cli.Coveralls')
+def test_debug_accepts_options(mock_coveralls):
+    # the debug subcommand shares the full option set with the default command
+    coveralls.cli.main(argv=['debug', '--rcfile=coveragerc', '--host=h'])
+    mock_coveralls.assert_called_with(
+        False, **coveralls_kwargs(rcfile='coveragerc', host='h'),
+    )
 
 
 @mock.patch.dict(
@@ -152,23 +188,61 @@ def test_real(mock_wear, mock_log):
 def test_rcfile(mock_coveralls):
     coveralls.cli.main(argv=['--rcfile=coveragerc'])
     mock_coveralls.assert_called_with(
-        True, config_file='coveragerc',
-        service_name=None,
-        base_dir='',
-        src_dir='',
+        True, **coveralls_kwargs(rcfile='coveragerc'),
     )
 
 
 @mock.patch.dict(os.environ, {}, clear=True)
 @mock.patch('coveralls.cli.Coveralls')
 def test_service_name(mock_coveralls):
-    coveralls.cli.main(argv=['--service=travis-pro'])
+    coveralls.cli.main(argv=['--service-name=travis-pro'])
     mock_coveralls.assert_called_with(
-        True, config_file='.coveragerc',
-        service_name='travis-pro',
-        base_dir='',
-        src_dir='',
+        True, **coveralls_kwargs(service_name='travis-pro'),
     )
+
+
+@mock.patch.dict(os.environ, {}, clear=True)
+@mock.patch('coveralls.cli.Coveralls')
+def test_host_and_skip_ssl_verify_and_parallel(mock_coveralls):
+    coveralls.cli.main(
+        argv=[
+            '--host=https://enterprise.example.com',
+            '--skip-ssl-verify',
+            '--parallel',
+        ],
+    )
+    mock_coveralls.assert_called_with(
+        True, **coveralls_kwargs(
+            host='https://enterprise.example.com',
+            parallel=True,
+            skip_ssl_verify=True,
+        ),
+    )
+
+
+@mock.patch.dict(os.environ, {}, clear=True)
+@mock.patch('coveralls.cli.Coveralls')
+def test_no_parallel_and_no_skip_ssl_verify_forward_false(mock_coveralls):
+    # --no-parallel / --no-skip-ssl-verify let the CLI express an explicit
+    # False override (matching library callers), which resolve() applies over
+    # an env/file value rather than being swallowed as an unset default.
+    coveralls.cli.main(argv=['--no-parallel', '--no-skip-ssl-verify'])
+    mock_coveralls.assert_called_with(
+        True, **coveralls_kwargs(parallel=False, skip_ssl_verify=False),
+    )
+
+
+@mock.patch.dict(os.environ, {}, clear=True)
+@mock.patch.object(coveralls.cli.log, 'warning')
+@mock.patch('coveralls.cli.Coveralls')
+def test_deprecated_service_alias_warns(mock_coveralls, mock_warning):
+    coveralls.cli.main(argv=['--service=travis-pro'])
+    mock_warning.assert_called_once_with(
+        '%s is deprecated and will be removed in a future release; use %s '
+        'instead.', '--service', '--service-name',
+    )
+    _, kwargs = mock_coveralls.call_args
+    assert kwargs['service_name'] == 'travis-pro'
 
 
 @mock.patch.object(coveralls.cli.log, 'exception')
@@ -208,51 +282,39 @@ def test_submit(mock_submit):
 
 @mock.patch('coveralls.cli.Coveralls')
 def test_base_dir_arg(mock_coveralls):
-    coveralls.cli.main(argv=['--basedir=foo'])
+    coveralls.cli.main(argv=['--base-dir=foo'])
     mock_coveralls.assert_called_with(
-        True, config_file='.coveragerc',
-        service_name=None,
-        base_dir='foo',
-        src_dir='',
+        True, **coveralls_kwargs(base_dir='foo'),
     )
 
 
 @mock.patch('coveralls.cli.Coveralls')
 def test_src_dir_arg(mock_coveralls):
-    coveralls.cli.main(argv=['--srcdir=foo'])
+    coveralls.cli.main(argv=['--src-dir=foo'])
     mock_coveralls.assert_called_with(
-        True, config_file='.coveragerc',
-        service_name=None,
-        base_dir='',
-        src_dir='foo',
+        True, **coveralls_kwargs(src_dir='foo'),
     )
 
 
 @mock.patch.dict(os.environ, {'TRAVIS': 'True'}, clear=True)
 @mock.patch('coveralls.cli.Coveralls')
-def test_no_timeout_args_not_forwarded(mock_coveralls):
+def test_unset_timeout_args_are_none(mock_coveralls):
+    # Unset options forward as None; resolve() drops them so nothing clobbers.
     coveralls.cli.main(argv=[])
-    _, kwargs = mock_coveralls.call_args
-    assert 'timeout' not in kwargs
-    assert 'connect_timeout' not in kwargs
-    assert 'read_timeout' not in kwargs
+    mock_coveralls.assert_called_with(True, **coveralls_kwargs())
 
 
 @mock.patch.dict(os.environ, {'TRAVIS': 'True'}, clear=True)
 @mock.patch('coveralls.cli.Coveralls')
 def test_timeout_arg(mock_coveralls):
     coveralls.cli.main(argv=['--timeout=30'])
-    _, kwargs = mock_coveralls.call_args
-    assert kwargs['timeout'] == 30.0
-    assert 'connect_timeout' not in kwargs
-    assert 'read_timeout' not in kwargs
+    mock_coveralls.assert_called_with(True, **coveralls_kwargs(timeout=30.0))
 
 
 @mock.patch.dict(os.environ, {'TRAVIS': 'True'}, clear=True)
 @mock.patch('coveralls.cli.Coveralls')
 def test_connect_and_read_timeout_args(mock_coveralls):
     coveralls.cli.main(argv=['--connect-timeout=5', '--read-timeout=90'])
-    _, kwargs = mock_coveralls.call_args
-    assert kwargs['connect_timeout'] == 5.0
-    assert kwargs['read_timeout'] == 90.0
-    assert 'timeout' not in kwargs
+    mock_coveralls.assert_called_with(
+        True, **coveralls_kwargs(connect_timeout=5.0, read_timeout=90.0),
+    )


### PR DESCRIPTION
## Summary

Give each setting one spelling across all interfaces: a setting `foo_bar` is
`--foo-bar` (CLI), `COVERALLS_FOO_BAR` (env), and `foo_bar` (config file /
kwarg).

## Changes

- Rename `coveralls_host`->`host` and `config_file`->`rcfile`.
- Expose `host`, `skip_ssl_verify`, and `parallel` as first-class CLI flags.
- Old CLI flags (`--service`, `--basedir`, `--srcdir`) and config keys
  (`coveralls_host`, `config_file`) still work as deprecated aliases that emit a
  warning.
- CLI defined once via shared `Annotated` option specs; the default command and
  the `debug` subcommand are thin wrappers over a shared dispatch, so they
  cannot drift apart.
- Docs updated to teach the naming convention and the deprecations.

## Behaviour changes (for the changelog)

Naming convention introduced: every setting `foo_bar` is spelled `--foo-bar`
(CLI), `COVERALLS_FOO_BAR` (env), and `foo_bar` (YAML). The old CLI flags and
config keys are deprecated but still honoured with a warning.

## Stack

PR **4 of 4** splitting #752. Based on #755. Together these four supersede #752.