### PR TITLE
feat(api): retry transient HTTP failures

### DIFF
--- a/coveralls/api.py
+++ b/coveralls/api.py
@@ -7,6 +7,9 @@ from typing import Any
 
 import coverage
 import requests
+import urllib3.exceptions
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from .configuration import Config
 from .configuration import resolve
@@ -15,6 +18,71 @@ from .reporter import CoverallReporter
 
 
 log = logging.getLogger('coveralls.api')
+
+# Transient failures worth retrying: server-side 5xx and rate limiting (429).
+RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+# urllib3's default allowed_methods excludes POST (non-idempotent); every call
+# we make is a POST, so we must opt POST in explicitly or nothing retries.
+RETRY_METHODS = frozenset({'POST'})
+# Exponential backoff with jitter. backoff_factor sets the base delay
+# (0.5, 1, 2, 4, ... seconds), backoff_jitter adds up to this many seconds of
+# randomness to spread out retries, and backoff_max caps any single wait.
+RETRY_BACKOFF_FACTOR = 0.5
+RETRY_BACKOFF_JITTER = 0.5
+RETRY_BACKOFF_MAX = 60
+
+
+def _build_session(retries: int) -> requests.Session:
+    """
+    Build a requests Session that retries transient HTTP failures.
+
+    With ``retries=0`` this is equivalent to a plain ``requests`` call: a
+    single attempt is made and connect/read timeouts surface as before.
+    ``raise_on_status=False`` keeps the final response (even a 5xx) flowing
+    back to the caller so the existing status handling stays in charge.
+    """
+    # urllib3 treats read=0 and read=False differently: read=0 raises
+    # MaxRetryError on a read timeout (which requests remaps to a bare
+    # ConnectionError), while read=False lets the ReadTimeoutError propagate as
+    # a requests Timeout. Mirror requests' own default (Retry(0, read=False))
+    # so the no-retry path still surfaces read timeouts as TimeoutError.
+    read = retries or False
+    retry = Retry(
+        total=retries, connect=retries, read=read, status=retries,
+        other=retries,
+        status_forcelist=RETRY_STATUSES,
+        allowed_methods=RETRY_METHODS,
+        backoff_factor=RETRY_BACKOFF_FACTOR,
+        backoff_jitter=RETRY_BACKOFF_JITTER,
+        backoff_max=RETRY_BACKOFF_MAX,
+        # Ignore Retry-After and always use our own bounded backoff: a server
+        # can send an arbitrarily large Retry-After (e.g. 3600s), and urllib3
+        # only started clamping it -- to 6 hours -- in 2.6.3, so on our
+        # supported range it is otherwise unbounded and could hang CI for
+        # hours. 429/503 are still retried; only the sleep length differs.
+        respect_retry_after_header=False,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session = requests.Session()
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session
+
+
+def _caused_by_timeout(exc: requests.exceptions.RequestException) -> bool:
+    """
+    Report whether a request failure was ultimately a timeout.
+
+    A single timeout raises a requests ``Timeout`` directly, but a timeout that
+    exhausts its retries surfaces as a ``ConnectionError`` wrapping a urllib3
+    ``MaxRetryError`` whose ``reason`` is a urllib3 ``TimeoutError``; unwrap
+    that so both read the same to the caller.
+    """
+    if isinstance(exc, requests.exceptions.Timeout):
+        return True
+    reason = getattr(exc.args[0] if exc.args else None, 'reason', None)
+    return isinstance(reason, urllib3.exceptions.TimeoutError)
 
 
 class Coveralls:
@@ -75,20 +143,34 @@ class Coveralls:
             return {}
         return self.submit_report(json_string)
 
-    def submit_report(self, json_string: str) -> dict[str, Any]:
-        endpoint = f'{self.config.host.rstrip("/")}/api/v1/jobs'
+    def _post(self, endpoint: str, **kwargs: Any) -> requests.Response:
+        """
+        POST to a coveralls endpoint, retrying transient failures.
+
+        A transient failure that exhausts its retries surfaces as a
+        connection/RetryError rather than a plain Timeout, so both are mapped
+        to clear exceptions here (see :func:`_caused_by_timeout`).
+        """
         verify = not self.config.skip_ssl_verify
         timeout = self.config.request_timeout
+        # Each command makes a single POST, so there is no pooling benefit from
+        # the session; it exists only to carry the retry adapter. Close it to
+        # release the connection pool and avoid a ResourceWarning.
         try:
-            response = requests.post(
-                endpoint, files={'json_file': json_string}, verify=verify,
-                timeout=timeout,
-            )
-        except requests.exceptions.Timeout as e:
-            raise TimeoutError(
-                f'Timed out submitting coverage to {endpoint} '
-                f'(connect={timeout[0]}s, read={timeout[1]}s)',
-            ) from e
+            with _build_session(self.config.retries) as session:
+                return session.post(
+                    endpoint, verify=verify, timeout=timeout, **kwargs,
+                )
+        except requests.exceptions.RequestException as e:
+            if _caused_by_timeout(e):
+                raise TimeoutError(
+                    f'Request timeout: {endpoint} (timeout={timeout})',
+                ) from e
+            raise RuntimeError(f'Could not submit coverage: {e}') from e
+
+    def submit_report(self, json_string: str) -> dict[str, Any]:
+        endpoint = f'{self.config.host.rstrip("/")}/api/v1/jobs'
+        response = self._post(endpoint, files={'json_file': json_string})
 
         if response.status_code == 422:
             if self.config.service_name.startswith('github'):
@@ -129,24 +211,12 @@ class Coveralls:
             payload['repo_name'] = os.environ.get('GITHUB_REPOSITORY')
 
         endpoint = f'{self.config.host.rstrip("/")}/webhook'
-        verify = not self.config.skip_ssl_verify
-        timeout = self.config.request_timeout
-        try:
-            response = requests.post(
-                endpoint, json=payload, verify=verify, timeout=timeout,
-            )
-        except requests.exceptions.Timeout as e:
-            raise TimeoutError(
-                f'Timed out finishing parallel jobs at {endpoint} '
-                f'(connect={timeout[0]}s, read={timeout[1]}s)',
-            ) from e
+        response = self._post(endpoint, json=payload)
         try:
             response.raise_for_status()
             data: dict[str, Any] = response.json()
         except Exception as e:
-            raise RuntimeError(
-                f'Parallel finish failed: {e}',
-            ) from e
+            raise RuntimeError(f'Could not submit coverage: {e}') from e
 
         if 'error' in data:
             exc = data['error']

--- a/coveralls/cli.py
+++ b/coveralls/cli.py
@@ -83,8 +83,9 @@ def _make_coveralls(
     parallel: bool | None = None,
     timeout: float | None = None,
     connect_timeout: float | None = None, read_timeout: float | None = None,
+    retries: int | None = None,
 ) -> Coveralls:
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments,too-many-locals
     # Modifiers not exposed by a command default to None; resolve() drops unset
     # ones so nothing clobbers env/config. An explicit value (incl. a False
     # from --no-parallel) overrides.
@@ -107,6 +108,7 @@ def _make_coveralls(
         'timeout': timeout,
         'connect_timeout': connect_timeout,
         'read_timeout': read_timeout,
+        'retries': retries,
     }
     return Coveralls(token_required, **overrides)
 
@@ -253,6 +255,14 @@ _ReadTimeout = Annotated[
         '--read-timeout', help='Read timeout, in seconds (default: 60).',
     ),
 ]
+_Retries = Annotated[
+    int | None,
+    typer.Option(
+        '--retries',
+        help='Retry transient HTTP failures this many times (default: 0). '
+             'Uses exponential backoff with jitter.',
+    ),
+]
 _Version = Annotated[
     bool | None,
     typer.Option(
@@ -312,6 +322,7 @@ HTTP_OPTIONS: dict[str, CollectionOption] = {
     'timeout': (_Timeout, None),
     'connect_timeout': (_ConnectTimeout, None),
     'read_timeout': (_ReadTimeout, None),
+    'retries': (_Retries, None),
 }
 
 

--- a/coveralls/configuration.py
+++ b/coveralls/configuration.py
@@ -27,6 +27,8 @@ TOKENLESS_CI_SERVICES = frozenset({'travis-ci'})
 DEFAULT_CONNECT_TIMEOUT = 10
 DEFAULT_READ_TIMEOUT = 60
 
+DEFAULT_RETRIES = 0
+
 # Fields sent to the coveralls.io API -- every job parameter the /jobs endpoint
 # accepts and lets the caller set. Everything else on Config controls local
 # client behaviour and must never enter the submitted payload.
@@ -89,6 +91,7 @@ class Config:
     timeout: float | None = None
     connect_timeout: float | None = None
     read_timeout: float | None = None
+    retries: int = DEFAULT_RETRIES
 
     def __post_init__(self) -> None:
         self.timeout = self._validate_timeout('timeout', self.timeout)
@@ -98,6 +101,7 @@ class Config:
         self.read_timeout = self._validate_timeout(
             'read_timeout', self.read_timeout,
         )
+        self.retries = self._validate_retries(self.retries)
 
     @staticmethod
     def _validate_timeout(name: str, raw: Any) -> float | None:
@@ -112,6 +116,26 @@ class Config:
         if value <= 0:
             raise ValueError(
                 f'Invalid {name} value {raw!r}: must be greater than 0.',
+            )
+        return value
+
+    @staticmethod
+    def _validate_retries(raw: Any) -> int:
+        # Only genuine ints and integer-valued strings (e.g. "3", from env vars
+        # or YAML) are accepted. Bools are excluded despite being ints, so
+        # retries=True is not silently read as 1; everything else is routed
+        # through int(str(...)), which never truncates, so floats and
+        # fractional strings (2.0, "1.5", "2.0") all raise.
+        is_int = isinstance(raw, int) and not isinstance(raw, bool)
+        try:
+            value = int(raw) if is_int else int(str(raw))
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                f'Invalid retries value {raw!r}: must be an integer.',
+            ) from e
+        if value < 0:
+            raise ValueError(
+                f'Invalid retries value {raw!r}: must not be negative.',
             )
         return value
 
@@ -318,6 +342,7 @@ def _from_environment() -> dict[str, Any]:
         'COVERALLS_RCFILE': 'rcfile',
         'COVERALLS_READ_TIMEOUT': 'read_timeout',
         'COVERALLS_REPO_TOKEN': 'repo_token',
+        'COVERALLS_RETRIES': 'retries',
         'COVERALLS_SERVICE_JOB_ID': 'service_job_id',
         'COVERALLS_SERVICE_JOB_NUMBER': 'service_job_number',
         'COVERALLS_SERVICE_NAME': 'service_name',

--- a/docs/usage/configuration.rst
+++ b/docs/usage/configuration.rst
@@ -91,6 +91,14 @@ Network requests to coveralls.io use a default connect timeout of 10 seconds and
 
 A connect- or read-specific value takes precedence over the overall ``--timeout``/``COVERALLS_TIMEOUT`` for its phase. Note that, like the underlying ``requests`` library, these are per-phase timeouts rather than a single wall-clock budget for the whole request.
 
+By default a failed request is not retried. If you occasionally hit transient HTTP failures (for example a ``502``/``504`` gateway error, or a connection reset), you can ask coveralls-python to retry them::
+
+    COVERALLS_RETRIES=3 coveralls
+    # or, via CLI flag:
+    coveralls --retries=3
+
+Retries use exponential backoff with jitter and apply to every command that talks to the API. Only transient failures are retried: connection errors, read timeouts, ``429`` (rate limited), and ``5xx`` responses. A ``422`` is treated as a configuration error and is never retried.
+
 If you are using named jobs, you can set::
 
     COVERALLS_FLAG_NAME="insert-name-here"
@@ -106,6 +114,7 @@ Sample ``.coveralls.yml`` file::
     timeout: 30
     connect_timeout: 5
     read_timeout: 90
+    retries: 3
 
 .. note::
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1011,4 +1011,4 @@ yaml = ["pyyaml"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10"
-content-hash = "051e45be8745756e154890dd1e05d7b27b36518a20fa6040b7dcf588d1785fd8"
+content-hash = "b864d680922dd47f1e07d62eea00e7d5c7bc6f470851a44ee1a00c2c2eabe9ef"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,9 @@ classifiers = [
 ]
 dependencies = [
     "coverage[toml] (>=6.3,<8.0)",
-    "requests (>=1.0.0,<3.0.0)",
-    "typer (>=0.12.0,<1.0.0)"
+    "requests (>=2.30.0,<3.0.0)",
+    "typer (>=0.12.0,<1.0.0)",
+    "urllib3 (>=2.0.0,<3.0.0)"
 ]
 
 [project.urls]

--- a/tests/api/config_test.py
+++ b/tests/api/config_test.py
@@ -26,6 +26,7 @@ def test_defaults() -> None:
     assert config.timeout is None
     assert config.connect_timeout is None
     assert config.read_timeout is None
+    assert config.retries == 0
 
 
 def test_to_payload_includes_only_set_payload_fields() -> None:
@@ -66,6 +67,7 @@ CLIENT_ONLY_FIELDS = (
     'timeout',
     'connect_timeout',
     'read_timeout',
+    'retries',
 )
 
 
@@ -82,6 +84,7 @@ def test_client_settings_never_leak_into_payload() -> None:
         timeout=30,
         connect_timeout=5,
         read_timeout=25,
+        retries=3,
     ).to_payload()
     for name in CLIENT_ONLY_FIELDS:
         assert name not in payload
@@ -139,6 +142,28 @@ def test_request_timeout_phase_specific_falls_back_to_default() -> None:
     assert Config(connect_timeout=5).request_timeout == (
         5.0, DEFAULT_READ_TIMEOUT,
     )
+
+
+def test_retries_defaults_to_zero() -> None:
+    assert Config().retries == 0
+
+
+@pytest.mark.parametrize(('raw', 'expected'), [(0, 0), (3, 3), ('5', 5)])
+def test_retries_accepts_non_negative_integers(
+    raw: Any, expected: int,
+) -> None:
+    assert Config(retries=raw).retries == expected
+
+
+@pytest.mark.parametrize('raw', ['abc', '1.5', '2.0', 2.5, 2.0, True, False])
+def test_retries_rejects_non_integers(raw: Any) -> None:
+    with pytest.raises(ValueError, match='must be an integer'):
+        Config(retries=raw)
+
+
+def test_retries_rejects_negative() -> None:
+    with pytest.raises(ValueError, match='must not be negative'):
+        Config(retries=-1)
 
 
 @pytest.mark.parametrize(

--- a/tests/api/reporter_test.py
+++ b/tests/api/reporter_test.py
@@ -7,6 +7,7 @@ import unittest.mock
 from typing import Any
 
 import pytest
+import responses
 
 from coveralls import Coveralls
 
@@ -269,17 +270,16 @@ class TestReporter:
         ):
             Coveralls(repo_token='xxx').get_coverage()
 
-    @unittest.mock.patch('requests.post')
-    def test_submit_report_422_github(
-        self, mock_post: unittest.mock.MagicMock,
-    ) -> None:
-        response_mock = unittest.mock.Mock()
-        response_mock.status_code = 422
-        mock_post.return_value = response_mock
-
+    @responses.activate
+    def test_submit_report_422_github(self) -> None:
+        responses.add(
+            responses.POST, 'https://coveralls.io/api/v1/jobs',
+            json={'error': 'nope'}, status=422,
+        )
         cov = Coveralls(repo_token='test_token', service_name='github')
 
         with unittest.mock.patch('coveralls.api.log.warning') as mock_warn:
-            cov.submit_report('{}')
+            with pytest.raises(RuntimeError):
+                cov.submit_report('{}')
             mock_warn.assert_called()
             assert '422' in mock_warn.call_args_list[0][0][0]

--- a/tests/api/resolve_test.py
+++ b/tests/api/resolve_test.py
@@ -252,6 +252,7 @@ def test_generic_ci_name_wins_over_specific_service() -> None:
         'COVERALLS_SERVICE_JOB_NUMBER': '1234',
         'COVERALLS_SKIP_SSL_VERIFY': '1',
         'COVERALLS_TIMEOUT': '30',
+        'COVERALLS_RETRIES': '4',
         'COVERALLS_RCFILE': 'custom.rc',
         'COVERALLS_BASE_DIR': 'base',
         'COVERALLS_SRC_DIR': 'src',
@@ -268,6 +269,7 @@ def test_environment_variables() -> None:
     assert config.service_job_number == '1234'
     assert config.skip_ssl_verify
     assert config.timeout == 30.0
+    assert config.retries == 4
     # base_dir/src_dir/rcfile complete the convention on the env interface
     assert config.rcfile == 'custom.rc'
     assert config.base_dir == 'base'

--- a/tests/api/wear_test.py
+++ b/tests/api/wear_test.py
@@ -2,291 +2,426 @@ import contextlib
 import json
 import os
 import pathlib
+import socket
 import tempfile
+import threading
 import unittest.mock
+from collections.abc import Iterator
+from typing import Any
 
 import coverage
 import pytest
 import requests
+import responses
+from requests.adapters import HTTPAdapter
 
 import coveralls
+from coveralls.api import _build_session
 from coveralls.api import log
+from coveralls.api import RETRY_BACKOFF_MAX
 
 
 EXPECTED = {
     'message': 'Job #7.1 - 44.58% Covered',
     'url': 'https://coveralls.io/jobs/5869',
 }
+JOBS_URL = 'https://coveralls.io/api/v1/jobs'
+WEBHOOK_URL = 'https://coveralls.io/webhook'
 
 
-@unittest.mock.patch('coveralls.api.requests')
-class WearTest(unittest.TestCase):
-    def setUp(self) -> None:
-        with contextlib.suppress(Exception):
-            pathlib.Path('.coverage').unlink()
+def req_kwargs(call: Any) -> Any:
+    # responses attaches the send() kwargs (timeout, verify, ...) to the
+    # captured request; they are not part of the typed PreparedRequest API.
+    return call.request.req_kwargs
 
-    def test_wet_run(
-        self, mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        mock_requests.post.return_value.json.return_value = EXPECTED
 
-        result = coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
-        assert result == EXPECTED
+@pytest.fixture(autouse=True)
+def _no_coverage_file() -> None:
+    with contextlib.suppress(Exception):
+        pathlib.Path('.coverage').unlink()
 
-    @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_client_settings_do_not_leak_into_payload(
-        self, _mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        # Regression guard at the create_data() boundary: base_dir/src_dir/
-        # rcfile and the timeout family are client-only and must never enter
-        # the submitted JSON.
-        api = coveralls.Coveralls(
-            repo_token='xxx',
-            service_name='travis-ci',
-            base_dir='foo',
-            src_dir='bar',
-            rcfile='.coveragerc',
-            timeout=30,
-            connect_timeout=5,
-            read_timeout=25,
-        )
-        with unittest.mock.patch.object(api, 'get_coverage', return_value=[]):
-            data = api.create_data()
 
-        for leaked in (
-            'base_dir', 'src_dir', 'rcfile', 'config_file',
-            'timeout', 'connect_timeout', 'read_timeout',
-        ):
-            assert leaked not in data
-        assert data['repo_token'] == 'xxx'
-        assert data['service_name'] == 'travis-ci'
+@pytest.fixture(autouse=True)
+def _no_backoff_sleep() -> Iterator[None]:
+    # urllib3's Retry sleeps between attempts; stub it so the retry tests stay
+    # instant regardless of the configured backoff strategy.
+    with unittest.mock.patch('urllib3.util.retry.time.sleep'):
+        yield
 
-    @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_set_payload_fields_are_forwarded_including_falsey(
-        self, _mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        # Every job field the API accepts is forwarded when set -- including
-        # run_at, and including explicitly-falsey values (parallel=False, a
-        # numeric 0 job id). Only genuinely-absent fields are dropped.
-        api = coveralls.Coveralls(
-            repo_token='xxx',
-            service_name='travis-ci',
-            run_at='2013-02-18 00:52:48 -0800',
-            parallel=False,
-            service_job_id=0,
-        )
-        with unittest.mock.patch.object(api, 'get_coverage', return_value=[]):
-            data = api.create_data()
 
-        assert data['run_at'] == '2013-02-18 00:52:48 -0800'
-        assert data['parallel'] is False
-        assert data['service_job_id'] == 0
+@responses.activate
+def test_wet_run() -> None:
+    responses.add(responses.POST, JOBS_URL, json=EXPECTED, status=200)
+    result = coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
+    assert result == EXPECTED
 
-    def test_merge(
-        self, _mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        with tempfile.NamedTemporaryFile() as coverage_file:
-            coverage_file.write(
-                b'{"source_files": [{"name": "foobar", "coverage": []}]}',
-            )
-            coverage_file.seek(0)
 
-            api = coveralls.Coveralls(repo_token='xxx')
-            api.merge(coverage_file.name)
-            result = api.create_report()
-
-            source_files = json.loads(result)['source_files']
-            assert source_files == [{'name': 'foobar', 'coverage': []}]
-
-    def test_merge_empty_data(
-        self, _mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        with tempfile.NamedTemporaryFile() as coverage_file:
-            coverage_file.write(b'{}')
-            coverage_file.seek(0)
-
-            api = coveralls.Coveralls(repo_token='xxx')
-            api.merge(coverage_file.name)
-            result = api.create_report()
-
-            source_files = json.loads(result)['source_files']
-            assert source_files == []
-
-    def test_merge_invalid_data(
-        self, _mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        with tempfile.NamedTemporaryFile() as coverage_file:
-            coverage_file.write(b'{"random": "stuff"}')
-            coverage_file.seek(0)
-
-            with unittest.mock.patch.object(log, 'warning') as logger:
-                api = coveralls.Coveralls(repo_token='xxx')
-                api.merge(coverage_file.name)
-                result = api.create_report()
-
-            source_files = json.loads(result)['source_files']
-            assert source_files == []
-
-            logger.assert_called_once_with(
-                'No data to be merged; does the json file contain '
-                '"source_files" data?',
-            )
-
-    def test_dry_run(
-        self, mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        mock_requests.post.return_value.json.return_value = EXPECTED
-
-        result = coveralls.Coveralls(repo_token='xxx').wear(dry_run=True)
-        assert not result
-
-    def test_repo_token_in_not_compromised_verbose(
-        self, mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        mock_requests.post.return_value.json.return_value = EXPECTED
-
-        with unittest.mock.patch.object(log, 'debug') as logger:
-            coveralls.Coveralls(repo_token='xxx').wear(dry_run=True)
-
-        assert 'xxx' not in logger.call_args[0][0]
-
-    def test_coveralls_unavailable(
-        self, mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        mock_requests.post.return_value.json.side_effect = ValueError
-        mock_requests.post.return_value.status_code = 500
-        mock_requests.post.return_value.text = '<html>Http 1./1 500</html>'
-
-        with pytest.raises(RuntimeError):
-            coveralls.Coveralls(repo_token='xxx').wear()
-
-    @unittest.mock.patch('coveralls.reporter.CoverallReporter.report')
-    def test_no_coverage(
-        self, report_files: unittest.mock.MagicMock,
-        mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        mock_requests.post.return_value.json.return_value = EXPECTED
-        report_files.side_effect = coverage.CoverageException(
-            'No data to report',
-        )
-
-        with pytest.raises(coverage.CoverageException):
-            coveralls.Coveralls(repo_token='xxx').wear()
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {
-            'COVERALLS_HOST': 'https://coveralls.my-enterprise.info',
-            'COVERALLS_SKIP_SSL_VERIFY': '1',
-        }, clear=True,
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_client_settings_do_not_leak_into_payload() -> None:
+    # Regression guard at the create_data() boundary: base_dir/src_dir/rcfile
+    # and the timeout/retries families are client-only and must never enter
+    # the submitted JSON.
+    api = coveralls.Coveralls(
+        repo_token='xxx',
+        service_name='travis-ci',
+        base_dir='foo',
+        src_dir='bar',
+        rcfile='.coveragerc',
+        timeout=30,
+        connect_timeout=5,
+        read_timeout=25,
+        retries=3,
     )
-    def test_coveralls_host_env_var_overrides_api_url(
-        self, mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
-        mock_requests.post.assert_called_once_with(
-            'https://coveralls.my-enterprise.info/api/v1/jobs',
-            files=unittest.mock.ANY, verify=False, timeout=(10, 60),
+    with unittest.mock.patch.object(api, 'get_coverage', return_value=[]):
+        data = api.create_data()
+
+    for leaked in (
+        'base_dir', 'src_dir', 'rcfile', 'config_file',
+        'timeout', 'connect_timeout', 'read_timeout', 'retries',
+    ):
+        assert leaked not in data
+    assert data['repo_token'] == 'xxx'
+    assert data['service_name'] == 'travis-ci'
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_set_payload_fields_are_forwarded_including_falsey() -> None:
+    # Every job field the API accepts is forwarded when set -- including
+    # run_at, and including explicitly-falsey values (parallel=False, a
+    # numeric 0 job id). Only genuinely-absent fields are dropped.
+    api = coveralls.Coveralls(
+        repo_token='xxx',
+        service_name='travis-ci',
+        run_at='2013-02-18 00:52:48 -0800',
+        parallel=False,
+        service_job_id=0,
+    )
+    with unittest.mock.patch.object(api, 'get_coverage', return_value=[]):
+        data = api.create_data()
+
+    assert data['run_at'] == '2013-02-18 00:52:48 -0800'
+    assert data['parallel'] is False
+    assert data['service_job_id'] == 0
+
+
+def test_merge() -> None:
+    with tempfile.NamedTemporaryFile() as coverage_file:
+        coverage_file.write(
+            b'{"source_files": [{"name": "foobar", "coverage": []}]}',
+        )
+        coverage_file.seek(0)
+
+        api = coveralls.Coveralls(repo_token='xxx')
+        api.merge(coverage_file.name)
+        result = api.create_report()
+
+        source_files = json.loads(result)['source_files']
+        assert source_files == [{'name': 'foobar', 'coverage': []}]
+
+
+def test_merge_empty_data() -> None:
+    with tempfile.NamedTemporaryFile() as coverage_file:
+        coverage_file.write(b'{}')
+        coverage_file.seek(0)
+
+        api = coveralls.Coveralls(repo_token='xxx')
+        api.merge(coverage_file.name)
+        result = api.create_report()
+
+        source_files = json.loads(result)['source_files']
+        assert source_files == []
+
+
+def test_merge_invalid_data() -> None:
+    with tempfile.NamedTemporaryFile() as coverage_file:
+        coverage_file.write(b'{"random": "stuff"}')
+        coverage_file.seek(0)
+
+        with unittest.mock.patch.object(log, 'warning') as logger:
+            api = coveralls.Coveralls(repo_token='xxx')
+            api.merge(coverage_file.name)
+            result = api.create_report()
+
+        source_files = json.loads(result)['source_files']
+        assert source_files == []
+
+        logger.assert_called_once_with(
+            'No data to be merged; does the json file contain '
+            '"source_files" data?',
         )
 
-    @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_host_and_skip_ssl_verify_via_override(
-        self, mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        # host/skip_ssl_verify are first-class Config fields, settable through
-        # any channel -- here as explicit overrides, not just env vars.
-        coveralls.Coveralls(
-            repo_token='xxx',
-            host='https://coveralls.my-enterprise.info',
-            skip_ssl_verify=True,
-        ).wear(dry_run=False)
-        mock_requests.post.assert_called_once_with(
-            'https://coveralls.my-enterprise.info/api/v1/jobs',
-            files=unittest.mock.ANY, verify=False, timeout=(10, 60),
-        )
 
-    @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_api_call_uses_default_host_if_no_env_var_set(
-        self, mock_requests: unittest.mock.MagicMock,
-    ) -> None:
+@responses.activate
+def test_dry_run() -> None:
+    result = coveralls.Coveralls(repo_token='xxx').wear(dry_run=True)
+    assert not result
+    assert not responses.calls
+
+
+@responses.activate
+def test_repo_token_in_not_compromised_verbose() -> None:
+    with unittest.mock.patch.object(log, 'debug') as logger:
+        coveralls.Coveralls(repo_token='xxx').wear(dry_run=True)
+
+    assert 'xxx' not in logger.call_args[0][0]
+
+
+@responses.activate
+def test_coveralls_unavailable() -> None:
+    responses.add(
+        responses.POST, JOBS_URL,
+        body='<html>Http 1./1 500</html>', status=500,
+    )
+    with pytest.raises(RuntimeError):
+        coveralls.Coveralls(repo_token='xxx').wear()
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+@unittest.mock.patch('coveralls.reporter.CoverallReporter.report')
+def test_no_coverage(report_files: unittest.mock.MagicMock) -> None:
+    report_files.side_effect = coverage.CoverageException('No data to report')
+    with pytest.raises(coverage.CoverageException):
+        coveralls.Coveralls(repo_token='xxx').wear()
+
+
+@unittest.mock.patch.dict(
+    os.environ,
+    {
+        'COVERALLS_HOST': 'https://coveralls.my-enterprise.info',
+        'COVERALLS_SKIP_SSL_VERIFY': '1',
+    }, clear=True,
+)
+@responses.activate
+def test_coveralls_host_env_var_overrides_api_url() -> None:
+    endpoint = 'https://coveralls.my-enterprise.info/api/v1/jobs'
+    responses.add(responses.POST, endpoint, json=EXPECTED, status=200)
+    coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == endpoint
+    assert req_kwargs(responses.calls[0])['verify'] is False
+    assert req_kwargs(responses.calls[0])['timeout'] == (10, 60)
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+@responses.activate
+def test_host_and_skip_ssl_verify_via_override() -> None:
+    # host/skip_ssl_verify are first-class Config fields, settable through any
+    # channel -- here as explicit overrides, not just env vars.
+    endpoint = 'https://coveralls.my-enterprise.info/api/v1/jobs'
+    responses.add(responses.POST, endpoint, json=EXPECTED, status=200)
+    coveralls.Coveralls(
+        repo_token='xxx',
+        host='https://coveralls.my-enterprise.info',
+        skip_ssl_verify=True,
+    ).wear(dry_run=False)
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == endpoint
+    assert req_kwargs(responses.calls[0])['verify'] is False
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+@responses.activate
+def test_api_call_uses_default_host_if_no_env_var_set() -> None:
+    responses.add(responses.POST, JOBS_URL, json=EXPECTED, status=200)
+    coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
+
+    assert len(responses.calls) == 1
+    assert responses.calls[0].request.url == JOBS_URL
+    assert req_kwargs(responses.calls[0])['verify'] is True
+    assert req_kwargs(responses.calls[0])['timeout'] == (10, 60)
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+@responses.activate
+def test_submit_report_uses_default_timeout() -> None:
+    responses.add(responses.POST, JOBS_URL, json=EXPECTED, status=200)
+    coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
+    assert req_kwargs(responses.calls[0])['timeout'] == (10, 60)
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+@responses.activate
+def test_submit_report_raises_on_timeout() -> None:
+    responses.add(
+        responses.POST, JOBS_URL,
+        body=requests.exceptions.ConnectTimeout('boom'),
+    )
+    with pytest.raises(TimeoutError, match=r'Request timeout'):
         coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
-        mock_requests.post.assert_called_once_with(
-            'https://coveralls.io/api/v1/jobs',
-            files=unittest.mock.ANY,
-            verify=True,
-            timeout=(10, 60),
+
+
+@contextlib.contextmanager
+def _hanging_server() -> Iterator[str]:
+    # A server that accepts connections in the background but never responds,
+    # so connects succeed and every request hits a read timeout. responses
+    # cannot exercise this: it short-circuits urllib3's transport, and an
+    # injected ReadTimeout does not reproduce urllib3's read=0/False remapping
+    # nor the ConnectionError-wrapped MaxRetryError from exhausted retries.
+    server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    server.bind(('127.0.0.1', 0))
+    server.listen(5)
+    held: list[socket.socket] = []
+    stop = threading.Event()
+
+    def accept_loop() -> None:
+        server.settimeout(0.1)
+        while not stop.is_set():
+            with contextlib.suppress(OSError):
+                conn, _ = server.accept()
+                held.append(conn)
+
+    thread = threading.Thread(target=accept_loop, daemon=True)
+    thread.start()
+    try:
+        yield f'http://127.0.0.1:{server.getsockname()[1]}'
+    finally:
+        stop.set()
+        thread.join(timeout=1)
+        for conn in held:
+            conn.close()
+        server.close()
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_submit_report_read_timeout_raises_timeout_error() -> None:
+    # Regression guard: with retries off (the default) a read timeout must
+    # still surface as TimeoutError, not the generic "Could not submit
+    # coverage" RuntimeError. See _build_session's read=0/False handling.
+    with _hanging_server() as host:
+        api = coveralls.Coveralls(
+            repo_token='xxx', host=host,
+            connect_timeout=5, read_timeout=0.5,
         )
+        with pytest.raises(TimeoutError, match=r'Request timeout'):
+            api.wear(dry_run=False)
 
-    @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_submit_report_uses_default_timeout(
-        self, mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        mock_requests.post.return_value.json.return_value = EXPECTED
-        coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
-        _, kwargs = mock_requests.post.call_args
-        assert kwargs['timeout'] == (10, 60)
 
-    @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_submit_report_raises_on_timeout(
-        self, mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        mock_requests.exceptions.Timeout = requests.exceptions.Timeout
-        mock_requests.post.side_effect = requests.exceptions.Timeout('boom')
-        with pytest.raises(
-            TimeoutError,
-            match=r'Timed out submitting coverage',
-        ):
-            coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+def test_submit_report_exhausted_read_timeout_raises_timeout_error() -> None:
+    # With retries on, an exhausted read timeout surfaces from requests as a
+    # ConnectionError wrapping a urllib3 timeout; it must still be reported as
+    # the detailed TimeoutError, not the generic RuntimeError.
+    with _hanging_server() as host:
+        api = coveralls.Coveralls(
+            repo_token='xxx', host=host,
+            connect_timeout=5, read_timeout=0.3, retries=2,
+        )
+        with pytest.raises(TimeoutError, match=r'Request timeout'):
+            api.wear(dry_run=False)
 
-    @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_parallel_finish_uses_default_timeout(
-        self, mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        mock_requests.post.return_value.json.return_value = {'done': True}
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+@responses.activate
+def test_parallel_finish_uses_default_timeout() -> None:
+    responses.add(responses.POST, WEBHOOK_URL, json={'done': True}, status=200)
+    coveralls.Coveralls(repo_token='xxx').parallel_finish()
+    assert req_kwargs(responses.calls[0])['timeout'] == (10, 60)
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+@responses.activate
+def test_parallel_finish_raises_on_timeout() -> None:
+    responses.add(
+        responses.POST, WEBHOOK_URL,
+        body=requests.exceptions.ConnectTimeout('boom'),
+    )
+    with pytest.raises(TimeoutError, match=r'Request timeout'):
         coveralls.Coveralls(repo_token='xxx').parallel_finish()
-        _, kwargs = mock_requests.post.call_args
-        assert kwargs['timeout'] == (10, 60)
 
-    @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_parallel_finish_raises_on_timeout(
-        self, mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        mock_requests.exceptions.Timeout = requests.exceptions.Timeout
-        mock_requests.post.side_effect = requests.exceptions.Timeout('boom')
-        with pytest.raises(
-            TimeoutError,
-            match=r'Timed out finishing parallel jobs',
-        ):
-            coveralls.Coveralls(repo_token='xxx').parallel_finish()
 
-    @unittest.mock.patch.dict(os.environ, {}, clear=True)
-    def test_submit_report_resubmission(
-        self, mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        # This would trigger the resubmission condition
-        mock_requests.post.return_value.status_code = 422
-        result = coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+@responses.activate
+def test_submit_report_retries_transient_then_succeeds() -> None:
+    responses.add(responses.POST, JOBS_URL, json={'e': 1}, status=502)
+    responses.add(responses.POST, JOBS_URL, json={'e': 1}, status=503)
+    responses.add(responses.POST, JOBS_URL, json=EXPECTED, status=200)
 
-        # A new service_job_id is created
-        mock_requests.post.return_value.json.return_value = EXPECTED
-        result = coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
-
-        assert result == EXPECTED
-
-    @unittest.mock.patch.dict(
-        os.environ,
-        {'GITHUB_REPOSITORY': 'test/repo'},
-        clear=True,
+    result = coveralls.Coveralls(repo_token='xxx', retries=2).wear(
+        dry_run=False,
     )
-    def test_submit_report_resubmission_github(
-        self, mock_requests: unittest.mock.MagicMock,
-    ) -> None:
-        # This would trigger the resubmission condition, for github
-        mock_requests.post.return_value.status_code = 422
-        result = coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
 
-        # A new service_job_id is created, null for github
-        mock_requests.post.return_value.json.return_value = EXPECTED
-        result = coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
+    assert result == EXPECTED
+    assert len(responses.calls) == 3
 
-        assert result == EXPECTED
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+@responses.activate
+def test_submit_report_retries_exhausted_raises() -> None:
+    for _ in range(5):
+        responses.add(responses.POST, JOBS_URL, json={'e': 1}, status=500)
+
+    with pytest.raises(RuntimeError):
+        coveralls.Coveralls(repo_token='xxx', retries=2).wear(dry_run=False)
+
+    # one initial attempt plus two retries
+    assert len(responses.calls) == 3
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+@responses.activate
+def test_submit_report_retries_on_429() -> None:
+    responses.add(responses.POST, JOBS_URL, json={'e': 1}, status=429)
+    responses.add(responses.POST, JOBS_URL, json=EXPECTED, status=200)
+
+    result = coveralls.Coveralls(repo_token='xxx', retries=1).wear(
+        dry_run=False,
+    )
+
+    assert result == EXPECTED
+    assert len(responses.calls) == 2
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+@responses.activate
+def test_submit_report_does_not_retry_422() -> None:
+    # A 422 is a client/configuration error, never a transient failure: it
+    # must not be retried even when retries are configured.
+    for _ in range(5):
+        responses.add(responses.POST, JOBS_URL, json={'e': 1}, status=422)
+
+    with pytest.raises(RuntimeError):
+        coveralls.Coveralls(repo_token='xxx', retries=3).wear(dry_run=False)
+
+    assert len(responses.calls) == 1
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+@responses.activate
+def test_submit_report_defaults_to_no_retries() -> None:
+    # Regression guard: with no retries configured a single attempt is made,
+    # preserving the historical behaviour.
+    for _ in range(5):
+        responses.add(responses.POST, JOBS_URL, json={'e': 1}, status=500)
+
+    with pytest.raises(RuntimeError):
+        coveralls.Coveralls(repo_token='xxx').wear(dry_run=False)
+
+    assert len(responses.calls) == 1
+
+
+def test_retries_do_not_honour_retry_after_header() -> None:
+    # A server can send an arbitrarily large Retry-After (e.g. 3600s); urllib3
+    # only began clamping it -- to 6 hours -- in 2.6.3, so honouring it could
+    # hang CI for hours on our supported range. Guard that we ignore the header
+    # and rely on our own bounded backoff instead. This cannot be exercised via
+    # responses, which does not drive urllib3's retry sleep machinery.
+    adapter = _build_session(3).get_adapter('https://coveralls.io')
+    assert isinstance(adapter, HTTPAdapter)
+    retry = adapter.max_retries
+    assert retry.respect_retry_after_header is False
+    assert retry.backoff_max == RETRY_BACKOFF_MAX
+
+
+@unittest.mock.patch.dict(os.environ, {}, clear=True)
+@responses.activate
+def test_parallel_finish_retries_transient_then_succeeds() -> None:
+    responses.add(responses.POST, WEBHOOK_URL, json={'e': 1}, status=503)
+    responses.add(responses.POST, WEBHOOK_URL, json={'done': True}, status=200)
+
+    coveralls.Coveralls(repo_token='xxx', retries=1).parallel_finish()
+
+    assert len(responses.calls) == 2

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -58,6 +58,7 @@ def coveralls_kwargs(**overrides: Any) -> dict[str, Any]:
         'timeout': None,
         'connect_timeout': None,
         'read_timeout': None,
+        'retries': None,
     }
     kwargs.update(overrides)
     return kwargs

--- a/uv.lock
+++ b/uv.lock
@@ -249,6 +249,7 @@ dependencies = [
     { name = "coverage", extra = ["toml"] },
     { name = "requests" },
     { name = "typer" },
+    { name = "urllib3" },
 ]
 
 [package.optional-dependencies]
@@ -269,8 +270,9 @@ docs = [
 requires-dist = [
     { name = "coverage", extras = ["toml"], specifier = ">=6.3,<8.0" },
     { name = "pyyaml", marker = "extra == 'yaml'", specifier = ">=3.10,<7.0" },
-    { name = "requests", specifier = ">=1.0.0,<3.0.0" },
+    { name = "requests", specifier = ">=2.30.0,<3.0.0" },
     { name = "typer", specifier = ">=0.12.0,<1.0.0" },
+    { name = "urllib3", specifier = ">=2.0.0,<3.0.0" },
 ]
 provides-extras = ["yaml"]
 


### PR DESCRIPTION
## Summary

Adds optional retries for transient HTTP failures when talking to the coveralls.io API, resolving #572.

API POSTs now go through a `requests.Session` with a `urllib3` `Retry` adapter, so transient failures can be retried with **exponential backoff and jitter**. This applies to every command that talks to the API (`submit`/default, `upload`, `finish`, `save`, `debug`).

### Behaviour
- **Off by default** — with no configuration a single attempt is made, preserving current behaviour.
- Retryable failures: connection errors, read timeouts, `429` (rate limited), and `5xx` responses.
- A `422` is treated as a configuration error and is **never** retried (the existing GitHub service-name guidance is preserved).

### Configuration
Set the retry count via any of the standard channels:
- `coveralls --retries=3`
- `COVERALLS_RETRIES=3`
- `retries: 3` in `.coveralls.yml`

## Implementation notes
- Added a validated `retries` field to `Config` (non-negative integer).
- Added `urllib3 (>=2.0.0)` as a direct dependency (required for `backoff_jitter`) and bumped the `requests` floor to `>=2.30.0`; both lockfiles updated.
- Extracted a shared `Coveralls._post` helper used by both `submit_report` and `parallel_finish`.

## Testing
- Migrated the API HTTP tests to the `responses` library for higher fidelity (real `requests`/`Session`/`Retry`, actual status sequences and call counts).
- This replaces the previous fake "resubmission" tests (which asserted logic that did not exist) with real retry coverage: transient-then-success, exhaustion, `429` retry, `422`-not-retried, default-off regression guard, and `parallel_finish` retries.

`pre-commit run -a` clean; 160 passed / 1 skipped.